### PR TITLE
fix: specify eslint config file to avoid duplication error

### DIFF
--- a/pkg/js/package.json
+++ b/pkg/js/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build",
     "test": "jest --config ./jest.config.js",
     "typecheck": "tsc  --skipLibCheck",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint -c .eslintrc.js --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "format:check": "prettier --check **/*.ts",
     "format:fix": "prettier --write **/*.ts"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

When used as a submodule, eslint detects multiple eslint configs and fails out. Explicitly set location of config.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
