### PR TITLE
feat: First cut of autocompletion suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,4 +100,4 @@ build-antlr-container:
 
 .PHONY: antlr-gen-base
 antlr-gen-base: build-antlr-container
-	${ANTLR_CMD} -Dlanguage=${language} -o pkg/${packageName}/gen /app/OpenFGALexer.g4 /app/OpenFGAParser.g4
+	${ANTLR_CMD} -Dlanguage=${language} -o pkg/${packageName}/gen /app/OpenFGALexer.g4 /app/OpenFGAParser.g4 -visitor

--- a/pkg/js/gen/OpenFGAParser.ts
+++ b/pkg/js/gen/OpenFGAParser.ts
@@ -12,6 +12,8 @@ import {
 	Interval, IntervalSet
 } from 'antlr4';
 import OpenFGAParserListener from "./OpenFGAParserListener.js";
+import OpenFGAParserVisitor from "./OpenFGAParserVisitor.js";
+
 // for running tests with parameters, TODO: discuss strategy for typed parameters in CI
 // eslint-disable-next-line no-unused-vars
 type int = number;
@@ -1770,6 +1772,14 @@ export class MainContext extends ParserRuleContext {
 	 		listener.exitMain(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitMain) {
+			return visitor.visitMain(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1792,6 +1802,14 @@ export class IndentationContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitIndentation) {
 	 		listener.exitIndentation(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitIndentation) {
+			return visitor.visitIndentation(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1845,6 +1863,14 @@ export class ModelHeaderContext extends ParserRuleContext {
 	 		listener.exitModelHeader(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitModelHeader) {
+			return visitor.visitModelHeader(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1870,6 +1896,14 @@ export class TypeDefsContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitTypeDefs) {
 	 		listener.exitTypeDefs(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitTypeDefs) {
+			return visitor.visitTypeDefs(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -1926,6 +1960,14 @@ export class TypeDefContext extends ParserRuleContext {
 	 		listener.exitTypeDef(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitTypeDef) {
+			return visitor.visitTypeDef(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -1974,6 +2016,14 @@ export class RelationDeclarationContext extends ParserRuleContext {
 	 		listener.exitRelationDeclaration(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDeclaration) {
+			return visitor.visitRelationDeclaration(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2004,6 +2054,14 @@ export class RelationDefContext extends ParserRuleContext {
 	 		listener.exitRelationDef(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDef) {
+			return visitor.visitRelationDef(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2032,6 +2090,14 @@ export class RelationDefPartialsContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefPartials) {
 	 		listener.exitRelationDefPartials(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefPartials) {
+			return visitor.visitRelationDefPartials(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2073,6 +2139,14 @@ export class RelationDefPartialAllOrContext extends ParserRuleContext {
 	 		listener.exitRelationDefPartialAllOr(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefPartialAllOr) {
+			return visitor.visitRelationDefPartialAllOr(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2112,6 +2186,14 @@ export class RelationDefPartialAllAndContext extends ParserRuleContext {
 	 		listener.exitRelationDefPartialAllAnd(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefPartialAllAnd) {
+			return visitor.visitRelationDefPartialAllAnd(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2149,6 +2231,14 @@ export class RelationDefPartialAllButNotContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefPartialAllButNot) {
 	 		listener.exitRelationDefPartialAllButNot(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefPartialAllButNot) {
+			return visitor.visitRelationDefPartialAllButNot(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2196,6 +2286,14 @@ export class RelationDefDirectAssignmentContext extends ParserRuleContext {
 	 		listener.exitRelationDefDirectAssignment(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefDirectAssignment) {
+			return visitor.visitRelationDefDirectAssignment(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2223,6 +2321,14 @@ export class RelationDefRewriteContext extends ParserRuleContext {
 	 		listener.exitRelationDefRewrite(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefRewrite) {
+			return visitor.visitRelationDefRewrite(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2245,6 +2351,14 @@ export class RelationDefRelationOnSameObjectContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefRelationOnSameObject) {
 	 		listener.exitRelationDefRelationOnSameObject(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefRelationOnSameObject) {
+			return visitor.visitRelationDefRelationOnSameObject(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2283,6 +2397,14 @@ export class RelationDefRelationOnRelatedObjectContext extends ParserRuleContext
 	 		listener.exitRelationDefRelationOnRelatedObject(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefRelationOnRelatedObject) {
+			return visitor.visitRelationDefRelationOnRelatedObject(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2313,6 +2435,14 @@ export class RelationDefOperatorContext extends ParserRuleContext {
 	 		listener.exitRelationDefOperator(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefOperator) {
+			return visitor.visitRelationDefOperator(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2335,6 +2465,14 @@ export class RelationDefOperatorAndContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefOperatorAnd) {
 	 		listener.exitRelationDefOperatorAnd(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefOperatorAnd) {
+			return visitor.visitRelationDefOperatorAnd(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2361,6 +2499,14 @@ export class RelationDefOperatorOrContext extends ParserRuleContext {
 	 		listener.exitRelationDefOperatorOr(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefOperatorOr) {
+			return visitor.visitRelationDefOperatorOr(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2385,6 +2531,14 @@ export class RelationDefOperatorButNotContext extends ParserRuleContext {
 	 		listener.exitRelationDefOperatorButNot(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefOperatorButNot) {
+			return visitor.visitRelationDefOperatorButNot(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2407,6 +2561,14 @@ export class RelationDefKeywordFromContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefKeywordFrom) {
 	 		listener.exitRelationDefKeywordFrom(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefKeywordFrom) {
+			return visitor.visitRelationDefKeywordFrom(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2439,6 +2601,14 @@ export class RelationDefTypeRestrictionContext extends ParserRuleContext {
 	 		listener.exitRelationDefTypeRestriction(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefTypeRestriction) {
+			return visitor.visitRelationDefTypeRestriction(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2463,6 +2633,14 @@ export class RelationDefTypeRestrictionTypeContext extends ParserRuleContext {
 	 		listener.exitRelationDefTypeRestrictionType(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefTypeRestrictionType) {
+			return visitor.visitRelationDefTypeRestrictionType(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2485,6 +2663,14 @@ export class RelationDefTypeRestrictionRelationContext extends ParserRuleContext
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefTypeRestrictionRelation) {
 	 		listener.exitRelationDefTypeRestrictionRelation(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefTypeRestrictionRelation) {
+			return visitor.visitRelationDefTypeRestrictionRelation(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2520,6 +2706,14 @@ export class RelationDefTypeRestrictionWildcardContext extends ParserRuleContext
 	 		listener.exitRelationDefTypeRestrictionWildcard(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefTypeRestrictionWildcard) {
+			return visitor.visitRelationDefTypeRestrictionWildcard(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2550,6 +2744,14 @@ export class RelationDefTypeRestrictionUsersetContext extends ParserRuleContext 
 	 		listener.exitRelationDefTypeRestrictionUserset(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefTypeRestrictionUserset) {
+			return visitor.visitRelationDefTypeRestrictionUserset(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2572,6 +2774,14 @@ export class RelationDefGroupingContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRelationDefGrouping) {
 	 		listener.exitRelationDefGrouping(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationDefGrouping) {
+			return visitor.visitRelationDefGrouping(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2598,6 +2808,14 @@ export class RewriteComputedusersetNameContext extends ParserRuleContext {
 	 		listener.exitRewriteComputedusersetName(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRewriteComputedusersetName) {
+			return visitor.visitRewriteComputedusersetName(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2620,6 +2838,14 @@ export class RewriteTuplesetComputedusersetNameContext extends ParserRuleContext
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitRewriteTuplesetComputedusersetName) {
 	 		listener.exitRewriteTuplesetComputedusersetName(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRewriteTuplesetComputedusersetName) {
+			return visitor.visitRewriteTuplesetComputedusersetName(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2646,6 +2872,14 @@ export class RewriteTuplesetNameContext extends ParserRuleContext {
 	 		listener.exitRewriteTuplesetName(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRewriteTuplesetName) {
+			return visitor.visitRewriteTuplesetName(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2670,6 +2904,14 @@ export class RelationNameContext extends ParserRuleContext {
 	 		listener.exitRelationName(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitRelationName) {
+			return visitor.visitRelationName(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2692,6 +2934,14 @@ export class TypeNameContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitTypeName) {
 	 		listener.exitTypeName(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitTypeName) {
+			return visitor.visitTypeName(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2730,6 +2980,14 @@ export class CommentContext extends ParserRuleContext {
 	 		listener.exitComment(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitComment) {
+			return visitor.visitComment(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2763,6 +3021,14 @@ export class MultiLineCommentContext extends ParserRuleContext {
 	 		listener.exitMultiLineComment(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitMultiLineComment) {
+			return visitor.visitMultiLineComment(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2788,6 +3054,14 @@ export class SpacingContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitSpacing) {
 	 		listener.exitSpacing(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitSpacing) {
+			return visitor.visitSpacing(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2817,6 +3091,14 @@ export class NewlineContext extends ParserRuleContext {
 	 		listener.exitNewline(this);
 		}
 	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitNewline) {
+			return visitor.visitNewline(this);
+		} else {
+			return visitor.visitChildren(this);
+		}
+	}
 }
 
 
@@ -2839,6 +3121,14 @@ export class SchemaVersionContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitSchemaVersion) {
 	 		listener.exitSchemaVersion(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitSchemaVersion) {
+			return visitor.visitSchemaVersion(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }
@@ -2866,6 +3156,14 @@ export class NameContext extends ParserRuleContext {
 	public exitRule(listener: OpenFGAParserListener): void {
 	    if(listener.exitName) {
 	 		listener.exitName(this);
+		}
+	}
+	// @Override
+	public accept<Result>(visitor: OpenFGAParserVisitor<Result>): Result {
+		if (visitor.visitName) {
+			return visitor.visitName(this);
+		} else {
+			return visitor.visitChildren(this);
 		}
 	}
 }

--- a/pkg/js/gen/OpenFGAParserVisitor.ts
+++ b/pkg/js/gen/OpenFGAParserVisitor.ts
@@ -1,0 +1,276 @@
+// Generated from /app/OpenFGAParser.g4 by ANTLR 4.13.0
+
+import {ParseTreeVisitor} from 'antlr4';
+
+
+import { MainContext } from "./OpenFGAParser";
+import { IndentationContext } from "./OpenFGAParser";
+import { ModelHeaderContext } from "./OpenFGAParser";
+import { TypeDefsContext } from "./OpenFGAParser";
+import { TypeDefContext } from "./OpenFGAParser";
+import { RelationDeclarationContext } from "./OpenFGAParser";
+import { RelationDefContext } from "./OpenFGAParser";
+import { RelationDefPartialsContext } from "./OpenFGAParser";
+import { RelationDefPartialAllOrContext } from "./OpenFGAParser";
+import { RelationDefPartialAllAndContext } from "./OpenFGAParser";
+import { RelationDefPartialAllButNotContext } from "./OpenFGAParser";
+import { RelationDefDirectAssignmentContext } from "./OpenFGAParser";
+import { RelationDefRewriteContext } from "./OpenFGAParser";
+import { RelationDefRelationOnSameObjectContext } from "./OpenFGAParser";
+import { RelationDefRelationOnRelatedObjectContext } from "./OpenFGAParser";
+import { RelationDefOperatorContext } from "./OpenFGAParser";
+import { RelationDefOperatorAndContext } from "./OpenFGAParser";
+import { RelationDefOperatorOrContext } from "./OpenFGAParser";
+import { RelationDefOperatorButNotContext } from "./OpenFGAParser";
+import { RelationDefKeywordFromContext } from "./OpenFGAParser";
+import { RelationDefTypeRestrictionContext } from "./OpenFGAParser";
+import { RelationDefTypeRestrictionTypeContext } from "./OpenFGAParser";
+import { RelationDefTypeRestrictionRelationContext } from "./OpenFGAParser";
+import { RelationDefTypeRestrictionWildcardContext } from "./OpenFGAParser";
+import { RelationDefTypeRestrictionUsersetContext } from "./OpenFGAParser";
+import { RelationDefGroupingContext } from "./OpenFGAParser";
+import { RewriteComputedusersetNameContext } from "./OpenFGAParser";
+import { RewriteTuplesetComputedusersetNameContext } from "./OpenFGAParser";
+import { RewriteTuplesetNameContext } from "./OpenFGAParser";
+import { RelationNameContext } from "./OpenFGAParser";
+import { TypeNameContext } from "./OpenFGAParser";
+import { CommentContext } from "./OpenFGAParser";
+import { MultiLineCommentContext } from "./OpenFGAParser";
+import { SpacingContext } from "./OpenFGAParser";
+import { NewlineContext } from "./OpenFGAParser";
+import { SchemaVersionContext } from "./OpenFGAParser";
+import { NameContext } from "./OpenFGAParser";
+
+
+/**
+ * This interface defines a complete generic visitor for a parse tree produced
+ * by `OpenFGAParser`.
+ *
+ * @param <Result> The return type of the visit operation. Use `void` for
+ * operations with no return type.
+ */
+export default class OpenFGAParserVisitor<Result> extends ParseTreeVisitor<Result> {
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.main`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitMain?: (ctx: MainContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.indentation`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitIndentation?: (ctx: IndentationContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.modelHeader`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitModelHeader?: (ctx: ModelHeaderContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.typeDefs`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitTypeDefs?: (ctx: TypeDefsContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.typeDef`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitTypeDef?: (ctx: TypeDefContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDeclaration`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDeclaration?: (ctx: RelationDeclarationContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDef`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDef?: (ctx: RelationDefContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefPartials`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefPartials?: (ctx: RelationDefPartialsContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefPartialAllOr`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefPartialAllOr?: (ctx: RelationDefPartialAllOrContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefPartialAllAnd`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefPartialAllAnd?: (ctx: RelationDefPartialAllAndContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefPartialAllButNot`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefPartialAllButNot?: (ctx: RelationDefPartialAllButNotContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefDirectAssignment`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefDirectAssignment?: (ctx: RelationDefDirectAssignmentContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefRewrite`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefRewrite?: (ctx: RelationDefRewriteContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefRelationOnSameObject`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefRelationOnSameObject?: (ctx: RelationDefRelationOnSameObjectContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefRelationOnRelatedObject`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefRelationOnRelatedObject?: (ctx: RelationDefRelationOnRelatedObjectContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefOperator`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefOperator?: (ctx: RelationDefOperatorContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefOperatorAnd`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefOperatorAnd?: (ctx: RelationDefOperatorAndContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefOperatorOr`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefOperatorOr?: (ctx: RelationDefOperatorOrContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefOperatorButNot`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefOperatorButNot?: (ctx: RelationDefOperatorButNotContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefKeywordFrom`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefKeywordFrom?: (ctx: RelationDefKeywordFromContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefTypeRestriction`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefTypeRestriction?: (ctx: RelationDefTypeRestrictionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefTypeRestrictionType`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefTypeRestrictionType?: (ctx: RelationDefTypeRestrictionTypeContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefTypeRestrictionRelation`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefTypeRestrictionRelation?: (ctx: RelationDefTypeRestrictionRelationContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefTypeRestrictionWildcard`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefTypeRestrictionWildcard?: (ctx: RelationDefTypeRestrictionWildcardContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefTypeRestrictionUserset`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefTypeRestrictionUserset?: (ctx: RelationDefTypeRestrictionUsersetContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationDefGrouping`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationDefGrouping?: (ctx: RelationDefGroupingContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.rewriteComputedusersetName`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRewriteComputedusersetName?: (ctx: RewriteComputedusersetNameContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.rewriteTuplesetComputedusersetName`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRewriteTuplesetComputedusersetName?: (ctx: RewriteTuplesetComputedusersetNameContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.rewriteTuplesetName`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRewriteTuplesetName?: (ctx: RewriteTuplesetNameContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.relationName`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitRelationName?: (ctx: RelationNameContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.typeName`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitTypeName?: (ctx: TypeNameContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.comment`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitComment?: (ctx: CommentContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.multiLineComment`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitMultiLineComment?: (ctx: MultiLineCommentContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.spacing`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitSpacing?: (ctx: SpacingContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.newline`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitNewline?: (ctx: NewlineContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.schemaVersion`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitSchemaVersion?: (ctx: SchemaVersionContext) => Result;
+	/**
+	 * Visit a parse tree produced by `OpenFGAParser.name`.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	visitName?: (ctx: NameContext) => Result;
+}
+

--- a/pkg/js/index.ts
+++ b/pkg/js/index.ts
@@ -1,5 +1,6 @@
 import validateDsl, {ValidationOptions, ValidationRegex} from './validator/validate-dsl';
 import {DSLSyntaxError, DSLSyntaxSingleError, ModelValidationError, ModelValidationSingleError} from './errors';
+import {generateSymbols, SymbolMap} from './symbolcollector';
 
 export {
     validateDsl,
@@ -8,5 +9,8 @@ export {
     DSLSyntaxError,
     DSLSyntaxSingleError,
     ModelValidationError,
-    ModelValidationSingleError
+    ModelValidationSingleError,
+
+    generateSymbols,
+    SymbolMap,
 }

--- a/pkg/js/symbolcollector/__snapshots__/symbolcollector.test.ts.snap
+++ b/pkg/js/symbolcollector/__snapshots__/symbolcollector.test.ts.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateSymbols Visits tree and generates all symbols 1`] = `
+{
+  "literals": Set {
+    "model",
+    "schema",
+    "type",
+    "relations",
+    "define",
+  },
+  "operators": Set {
+    "and",
+    "or",
+    "but not",
+    "from",
+  },
+  "restrictions": Set {
+    "user",
+    "user:*",
+    "team",
+    "team:*",
+    "team#member",
+    "repo",
+    "repo:*",
+    "repo#admin",
+    "repo#maintainer",
+    "repo#owner",
+    "repo#reader",
+    "repo#triager",
+    "repo#writer",
+    "organization",
+    "organization:*",
+    "organization#member",
+    "organization#owner",
+    "organization#repo_admin",
+    "organization#repo_reader",
+    "organization#repo_writer",
+  },
+  "typeNames": {
+    "organization": Set {
+      "member",
+      "owner",
+      "repo_admin",
+      "repo_reader",
+      "repo_writer",
+    },
+    "repo": Set {
+      "admin",
+      "maintainer",
+      "owner",
+      "reader",
+      "triager",
+      "writer",
+    },
+    "team": Set {
+      "member",
+    },
+    "user": Set {},
+  },
+}
+`;

--- a/pkg/js/symbolcollector/index.ts
+++ b/pkg/js/symbolcollector/index.ts
@@ -1,7 +1,7 @@
 import OpenFGALexer from "../gen/OpenFGALexer";
 import OpenFGAParser, { TypeNameContext, RelationNameContext, MainContext } from "../gen/OpenFGAParser";
 import OpenFGAVisitor from "../gen/OpenFGAParserVisitor";
-import * as antlr from "antlr4";
+import { CharStream, CommonTokenStream, InputStream, TerminalNode } from "antlr4";
 
 export interface SymbolMap {
   typeNames: Record<string, Set<string>>;
@@ -43,15 +43,15 @@ class OpenFgaDslVisitor extends OpenFGAVisitor<void> {
     this.suggestions.restrictions.add(this.currentType + "#" + this.currentRelation);
   };
 
-  visitTerminal(node: antlr.TerminalNode): void {
+  visitTerminal(node: TerminalNode): void {
     if (!(node.parentCtx instanceof MainContext)) return;
   }
 }
 
 export function generateSymbols(dsl: string): SymbolMap {
-  const is = new antlr.InputStream(dsl);
-  const lexer = new OpenFGALexer(is as antlr.CharStream);
-  const stream = new antlr.CommonTokenStream(lexer);
+  const is = new InputStream(dsl);
+  const lexer = new OpenFGALexer(is as CharStream);
+  const stream = new CommonTokenStream(lexer);
 
   // Create the Parser
   const parser = new OpenFGAParser(stream);

--- a/pkg/js/symbolcollector/index.ts
+++ b/pkg/js/symbolcollector/index.ts
@@ -1,0 +1,64 @@
+import OpenFGALexer from "../gen/OpenFGALexer";
+import OpenFGAParser, { TypeNameContext, RelationNameContext, MainContext } from "../gen/OpenFGAParser";
+import OpenFGAVisitor from "../gen/OpenFGAParserVisitor";
+import * as antlr from "antlr4";
+
+export interface SymbolMap {
+  typeNames: Record<string, Set<string>>;
+  restrictions: Set<string>;
+  literals: Set<string>;
+  operators: Set<string>;
+}
+
+class OpenFgaDslVisitor extends OpenFGAVisitor<void> {
+  public suggestions: SymbolMap;
+  private currentType: string | undefined;
+  private currentRelation: string | undefined;
+
+  constructor() {
+    super();
+    this.suggestions = {
+      typeNames: {},
+      restrictions: new Set(),
+      literals: new Set(["model", "schema", "type", "relations", "define"]),
+      operators: new Set(["and", "or", "but not", "from"]),
+    };
+    this.currentType = undefined;
+    this.currentRelation = undefined;
+  }
+
+  visitTypeName = (ctx: TypeNameContext): void => {
+    this.currentType = ctx.getText();
+    this.suggestions.typeNames[this.currentType] = new Set();
+    this.suggestions.restrictions.add(this.currentType).add(this.currentType + ":*");
+  };
+
+  visitRelationName = (ctx: RelationNameContext): void => {
+    // Should never exit early
+    if (!this.currentType) return;
+    this.currentRelation = ctx.getText();
+
+    this.suggestions.typeNames[this.currentType].add(this.currentRelation);
+
+    this.suggestions.restrictions.add(this.currentType + "#" + this.currentRelation);
+  };
+
+  visitTerminal(node: antlr.TerminalNode): void {
+    if (!(node.parentCtx instanceof MainContext)) return;
+  }
+}
+
+export function generateSymbols(dsl: string): SymbolMap {
+  const is = new antlr.InputStream(dsl);
+  const lexer = new OpenFGALexer(is as antlr.CharStream);
+  const stream = new antlr.CommonTokenStream(lexer);
+
+  // Create the Parser
+  const parser = new OpenFGAParser(stream);
+  const parserContext = parser.main();
+  // Finally parse the expression
+  const visitor = new OpenFgaDslVisitor();
+  // @ts-ignore
+  visitor.visit(parserContext);
+  return visitor.suggestions;
+}

--- a/pkg/js/symbolcollector/symbolcollector.test.ts
+++ b/pkg/js/symbolcollector/symbolcollector.test.ts
@@ -1,5 +1,4 @@
 import { generateSymbols } from "./index";
-import validateDsl from "../validator/validate-dsl";
 
 describe("generateSymbols", () => {
   const dsl = `model
@@ -25,7 +24,6 @@ type organization
     define repo_writer: [user,organization#member]`;
 
   it(`Visits tree and generates all symbols`, () => {
-    validateDsl(dsl);
     const result = generateSymbols(dsl);
     expect(result).toMatchSnapshot();
   });

--- a/pkg/js/symbolcollector/symbolcollector.test.ts
+++ b/pkg/js/symbolcollector/symbolcollector.test.ts
@@ -1,0 +1,32 @@
+import { generateSymbols } from "./index";
+import validateDsl from "../validator/validate-dsl";
+
+describe("generateSymbols", () => {
+  const dsl = `model
+  schema 1.1
+type user
+type team
+  relations
+    define member: [user,team#member]
+type repo
+  relations
+    define admin: [user,team#member] or repo_admin from owner
+    define maintainer: [user,team#member] or admin
+    define owner: [organization]
+    define reader: [user,team#member] or triager or repo_reader from owner
+    define triager: [user,team#member] or writer
+    define writer: [user,team#member] or maintainer or repo_writer from owner
+type organization
+  relations
+    define member: [user] or owner
+    define owner: [user]
+    define repo_admin: [user,organization#member]
+    define repo_reader: [user,organization#member]
+    define repo_writer: [user,organization#member]`;
+
+  it(`Visits tree and generates all symbols`, () => {
+    validateDsl(dsl);
+    const result = generateSymbols(dsl);
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Visitor visits each typeName, relationName and builds up a collection of potentialy matching symbols.

```
model
  schema 1.1
type user
type team
  relations
    define member: [user,team#member]
type repo
  relations
    define admin: [user,team#member] or repo_admin from owner
    define maintainer: [user,team#member] or admin
    define owner: [organization]
    define reader: [user,team#member] or triager or repo_reader from owner
    define triager: [user,team#member] or writer
    define writer: [user,team#member] or maintainer or repo_writer from owner
type organization
  relations
    define member: [user] or owner
    define owner: [user]
    define repo_admin: [user,organization#member]
    define repo_reader: [user,organization#member]
    define repo_writer: [user,organization#member]
```
Returns;

```
{
  "literals": Set {
    "model",
    "schema",
    "type",
    "relations",
    "define",
  },
  "operators": Set {
    "and",
    "or",
    "but not",
    "from",
  },
  "restrictions": Set {
    "user",
    "user:*",
    "team",
    "team:*",
    "team#member",
    "repo",
    "repo:*",
    "repo#admin",
    "repo#maintainer",
    "repo#owner",
    "repo#reader",
    "repo#triager",
    "repo#writer",
    "organization",
    "organization:*",
    "organization#member",
    "organization#owner",
    "organization#repo_admin",
    "organization#repo_reader",
    "organization#repo_writer",
  },
  "typeNames": {
    "organization": Set {
      "member",
      "owner",
      "repo_admin",
      "repo_reader",
      "repo_writer",
    },
    "repo": Set {
      "admin",
      "maintainer",
      "owner",
      "reader",
      "triager",
      "writer",
    },
    "team": Set {
      "member",
    },
    "user": Set {},
  },
}
```

This could be built into the validation call to save time, or kept separate and only invoked after a successful validation.

Additional work needs to be done to make type restrictions contextual. Currently every restriction is added a sset.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
