### PR TITLE
chore: bump go version

### DIFF
--- a/pkg/go/go.mod
+++ b/pkg/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/language/pkg/go
 
-go 1.21.3
+go 1.21.4
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0


### PR DESCRIPTION
## Description
Bump go version

## References
https://pkg.go.dev/vuln/GO-2023-2186


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
