### PR TITLE
feat: add limited support for mixed operators in Golang binding

### DIFF
--- a/pkg/go/transformer/jsontodsl.go
+++ b/pkg/go/transformer/jsontodsl.go
@@ -184,17 +184,26 @@ func parseSubRelation(typeName string, relationName string, relationDefinition *
 	}
 
 	if relationDefinition.GetUnion() != nil {
-		parsedUnion, _ := parseUnion(typeName, relationName, relationDefinition, typeRestrictions)
+		parsedUnion, err := parseUnion(typeName, relationName, relationDefinition, typeRestrictions)
+		if err != nil {
+			return "", err
+		}
 		return fmt.Sprintf("(%s)", parsedUnion), nil
 	}
 
 	if relationDefinition.GetIntersection() != nil {
-		parsedIntersection, _ := parseIntersection(typeName, relationName, relationDefinition, typeRestrictions)
+		parsedIntersection, err := parseIntersection(typeName, relationName, relationDefinition, typeRestrictions)
+		if err != nil {
+			return "", err
+		}
 		return fmt.Sprintf("(%s)", parsedIntersection), nil
 	}
 
 	if relationDefinition.GetDifference() != nil {
-		parsedDiff, _ := parseDifference(typeName, relationName, relationDefinition, typeRestrictions)
+		parsedDiff, err := parseDifference(typeName, relationName, relationDefinition, typeRestrictions)
+		if err != nil {
+			return "", err
+		}
 		return fmt.Sprintf("(%s)", parsedDiff), nil
 	}
 

--- a/pkg/go/transformer/jsontodsl.go
+++ b/pkg/go/transformer/jsontodsl.go
@@ -30,7 +30,7 @@ func (v *DirectAssignmentValidator) reset() {
 
 var validator = DirectAssignmentValidator{
 	occurred:   0,
-	stateStack: make([]pb.Userset, 0),
+	stateStack: []pb.Userset{},
 }
 
 func (v *DirectAssignmentValidator) isFirstPosition(userset *pb.Userset) bool {
@@ -38,20 +38,21 @@ func (v *DirectAssignmentValidator) isFirstPosition(userset *pb.Userset) bool {
 		return true
 	}
 
-	// TODO nil handling
-	if userset.GetDifference().GetBase() != nil {
+	if userset.GetDifference() != nil && userset.GetDifference().GetBase() != nil {
 		if userset.GetDifference().GetBase().GetThis() != nil {
 			return true
 		} else {
 			return v.isFirstPosition(userset.GetDifference().GetBase())
 		}
-	} else if len(userset.GetIntersection().GetChild()) > 0 {
-		if userset.GetIntersection().GetChild()[0].GetThis() != nil {
-			return true
-		} else {
-			return v.isFirstPosition(userset.GetIntersection().GetChild()[0])
+	} else if userset.GetIntersection() != nil && userset.GetIntersection().GetChild() != nil {
+		if len(userset.GetIntersection().GetChild()) > 0 {
+			if userset.GetIntersection().GetChild()[0].GetThis() != nil {
+				return true
+			} else {
+				return v.isFirstPosition(userset.GetIntersection().GetChild()[0])
+			}
 		}
-	} else if len(userset.GetUnion().GetChild()) > 0 {
+	} else if userset.GetUnion() != nil && len(userset.GetUnion().GetChild()) > 0 {
 		if userset.GetUnion().GetChild()[0].GetThis() != nil {
 			return true
 		} else {

--- a/pkg/js/transformer/dsltojson.ts
+++ b/pkg/js/transformer/dsltojson.ts
@@ -274,11 +274,11 @@ class OpenFgaDslListener extends OpenFGAListener {
 
     let relationDef = parseExpression(rewrites, this.currentRelation?.operator);
 
-    const stack = this.rewriteStack.pop();
+    const popped = this.rewriteStack.pop();
 
     if (relationDef) {
-      this.currentRelation!.operator = stack?.operator;
-      this.currentRelation!.rewrites = [...stack!.rewrites, relationDef];
+      this.currentRelation!.operator = popped?.operator;
+      this.currentRelation!.rewrites = [...popped!.rewrites, relationDef];
     }
   };
 

--- a/pkg/js/transformer/jsontodsl.ts
+++ b/pkg/js/transformer/jsontodsl.ts
@@ -14,7 +14,7 @@ class DirectAssignmentValidator {
   stateStack: Userset[] = [];
 
   isFirstPosition = (userset: Userset): boolean => {
-    // Throw error is direct assignemnt is present, and not the first element.
+    // Throw error if direct assignment is present, and not the first element.
     if (userset.this) {
       return true;
     }
@@ -151,7 +151,7 @@ function parseSubRelation(
   typeRestrictions: RelationReference[],
 ): string {
   if (relationDefinition.this != null) {
-    // Make sure we no more than 1 reference for direct assignment in a given relation
+    // Make sure we have no more than 1 reference for direct assignment in a given relation
     validator.occured++;
     return parseThis(typeRestrictions);
   }


### PR DESCRIPTION
This PR adds initial support for mixed operators to the Golang bindings.

## Description

Golang binding implementation for the initial mixed operators support as done in #107. Similar to the JS implementation, this change does not support anything involving multiple references to direct assignment, or the presence of direct assignment not as the first entry, or references to `self/this`.

## References
- Golang implementation of JS bindings in #107 
- Closes #132 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
