### PR TITLE
chore: bump go version to 1.21

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '1.22'
+          go-version: '>=1.22'
           cache-dependency-path: './pkg/go/go.sum'
           check-latest: true
 

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -24,8 +24,28 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: '1.22'
+          cache-dependency-path: './pkg/go/go.sum'
+          check-latest: true
+
+      - name: Audit dependencies
+        run: make audit-go
+
+      - name: Lint
+        run: make lint-go
+
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -36,12 +56,12 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version-file: './pkg/go/go.mod'
+        go-version: ${{ matrix.go-version }}
         cache-dependency-path: './pkg/go/go.sum'
         check-latest: true
 
     - name: Build
-      run: make all-tests-go
+      run: make test-go
 
   release:
     runs-on: ubuntu-latest

--- a/pkg/go/go.mod
+++ b/pkg/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/language/pkg/go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0

--- a/pkg/go/go.mod
+++ b/pkg/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/language/pkg/go
 
-go 1.21
+go 1.21.3
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0


### PR DESCRIPTION
## Description

Now that 1.22 is out in theory we can bump this, it should fix the golangci-lint issues that we're seeing due to their minimum version being bumped

Alternatively, we could
* pin to a version of `golangci-lint` other than latest
* match how CI works for JS and run our vulncheck and linting on a newer version of Go and then run tests using all our supported versions of Go rather than pointing to the go.mod file.

Edit:

I had to move this to `1.21.3` due to this being the version set in https://github.com/openfga/api/blob/main/proto/go.mod and go was enforcing that be set rather than `1.21`


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
