### PR TITLE
chore(js): fix eslint warnings

### DIFF
--- a/.github/workflows/main-js.yaml
+++ b/.github/workflows/main-js.yaml
@@ -40,10 +40,7 @@ jobs:
       - name: Audit dependencies
         run: make audit-js
 
-      - name: Run Prettier
-        run: make format-js
-
-      - name: Run eslint
+      - name: Run eslint and prettier
         run: make lint-js
 
   build:

--- a/pkg/js/Makefile
+++ b/pkg/js/Makefile
@@ -19,13 +19,13 @@ test: init-deps
 	npm run test
 
 lint: init-deps
-	npm run lint
+	npm run lint;npm run format:check
 
 audit: init-deps
 	npm audit
 
 format: init-deps
-	npm run format:fix
+	npm run lint:fix;npm run format:fix
 
 all-tests: audit lint test
 	npx madge --circular --exclude '^dist|^gen' . --extensions ts,js

--- a/pkg/js/index.ts
+++ b/pkg/js/index.ts
@@ -1,3 +1,3 @@
-export * as validator from './validator';
-export * as transformer from './transformer';
-export * as errors from './errors';
+export * as validator from "./validator";
+export * as transformer from "./transformer";
+export * as errors from "./errors";

--- a/pkg/js/package.json
+++ b/pkg/js/package.json
@@ -15,7 +15,7 @@
     "postpublish": "rm -f README.md LICENSE",
     "test": "jest --config ./jest.config.js",
     "typecheck": "tsc  --skipLibCheck",
-    "lint": "eslint -c .eslintrc.js --ext .ts",
+    "lint": "eslint . -c .eslintrc.js --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "format:check": "prettier --check **/*.ts",
     "format:fix": "prettier --write **/*.ts"

--- a/pkg/js/transformer/dsltojson.ts
+++ b/pkg/js/transformer/dsltojson.ts
@@ -22,8 +22,6 @@ import OpenFGAParser, {
   RelationDefPartialsContext,
   RelationDefRewriteContext,
   RelationDefTypeRestrictionContext,
-  RelationRecurseContext,
-  RelationRecurseNoDirectContext,
   TypeDefContext,
   TypeDefsContext,
 } from "../gen/OpenFGAParser";
@@ -168,7 +166,7 @@ class OpenFgaDslListener extends OpenFGAListener {
     const relationName = ctx.relationName().getText();
     const rewrites = this.currentRelation?.rewrites;
 
-    let relationDef = parseExpression(rewrites, this.currentRelation?.operator);
+    const relationDef = parseExpression(rewrites, this.currentRelation?.operator);
 
     if (relationDef) {
       // Throw error if same named relation occurs more than once in a relationship definition block
@@ -250,17 +248,17 @@ class OpenFgaDslListener extends OpenFGAListener {
     this.currentRelation?.rewrites?.push(partialRewrite);
   };
 
-  exitRelationRecurse = (ctx: RelationRecurseContext) => {
+  exitRelationRecurse = () => {
     const rewrites = this.currentRelation?.rewrites;
 
-    let relationDef = parseExpression(rewrites, this.currentRelation?.operator);
+    const relationDef = parseExpression(rewrites, this.currentRelation?.operator);
 
     if (relationDef) {
       this.currentRelation!.rewrites = [relationDef];
     }
   };
 
-  enterRelationRecurseNoDirect = (ctx: RelationRecurseNoDirectContext) => {
+  enterRelationRecurseNoDirect = () => {
     this.rewriteStack?.push({
       rewrites: this.currentRelation!.rewrites!,
       operator: this.currentRelation!.operator!,
@@ -269,10 +267,10 @@ class OpenFgaDslListener extends OpenFGAListener {
     this.currentRelation!.rewrites = [];
   };
 
-  exitRelationRecurseNoDirect = (ctx: RelationRecurseNoDirectContext) => {
+  exitRelationRecurseNoDirect = () => {
     const rewrites = this.currentRelation?.rewrites;
 
-    let relationDef = parseExpression(rewrites, this.currentRelation?.operator);
+    const relationDef = parseExpression(rewrites, this.currentRelation?.operator);
 
     const popped = this.rewriteStack.pop();
 
@@ -351,7 +349,7 @@ class OpenFgaDslListener extends OpenFGAListener {
     this.currentCondition!.expression = ctx.getText().trim();
   };
 
-  exitCondition = (_ctx: ConditionContext) => {
+  exitCondition = () => {
     if (this.currentCondition) {
       this.authorizationModel.conditions![this.currentCondition.name!] = this.currentCondition!;
 

--- a/pkg/js/transformer/jsontodsl.ts
+++ b/pkg/js/transformer/jsontodsl.ts
@@ -95,7 +95,13 @@ function parseDifference(
   typeRestrictions: RelationReference[],
   validator: DirectAssignmentValidator,
 ): string {
-  const base = parseSubRelation(typeName, relationName, relationDefinition!.difference!.base!, typeRestrictions, validator);
+  const base = parseSubRelation(
+    typeName,
+    relationName,
+    relationDefinition!.difference!.base!,
+    typeRestrictions,
+    validator
+  );
   const difference = parseSubRelation(
     typeName,
     relationName,

--- a/pkg/js/transformer/jsontodsl.ts
+++ b/pkg/js/transformer/jsontodsl.ts
@@ -100,7 +100,7 @@ function parseDifference(
     relationName,
     relationDefinition!.difference!.base!,
     typeRestrictions,
-    validator
+    validator,
   );
   const difference = parseSubRelation(
     typeName,

--- a/pkg/js/util/exceptions.ts
+++ b/pkg/js/util/exceptions.ts
@@ -291,7 +291,7 @@ export const createSchemaVersionRequiredError = (props: BaseProps) => {
   const { errors, lines, lineIndex, symbol } = props;
   errors.push(
     constructValidationError({
-      message: `schema version required`,
+      message: "schema version required",
       lines,
       lineIndex,
       metadata: { symbol, errorType: ValidationError.SchemaVersionRequired },

--- a/pkg/js/validator/validate-dsl.ts
+++ b/pkg/js/validator/validate-dsl.ts
@@ -224,7 +224,7 @@ function hasEntryPointOrLoop(
         continue;
       }
 
-      const [hasEntry, ] = hasEntryPointOrLoop(typeMap, decodedType, decodedRelation, assignableRelation, visited);
+      const [hasEntry] = hasEntryPointOrLoop(typeMap, decodedType, decodedRelation, assignableRelation, visited);
       if (hasEntry) {
         return [true, false];
       }
@@ -275,7 +275,7 @@ function hasEntryPointOrLoop(
           continue;
         }
 
-        const [hasEntry, ] = hasEntryPointOrLoop(
+        const [hasEntry] = hasEntryPointOrLoop(
           typeMap,
           assignableType,
           computedRelationName,

--- a/pkg/js/validator/validate-dsl.ts
+++ b/pkg/js/validator/validate-dsl.ts
@@ -3,7 +3,6 @@ import { Keyword, ReservedKeywords } from "./keywords";
 import { parseDSL } from "../transformer";
 import { ConfigurationError, DSLSyntaxError, ModelValidationError, ModelValidationSingleError } from "../errors";
 import { exceptionCollector } from "../util/exceptions";
-import { string } from "yaml/dist/schema/common/string";
 
 // eslint-disable-next-line no-useless-escape
 export const defaultTypeRule = "^[^:#@\\s]{1,254}$";
@@ -38,7 +37,7 @@ interface RelationTargetParserResult {
   rewrite: RewriteType;
 }
 
-const deepCopy = (object: any): any => {
+const deepCopy = <T>(object: T): T => {
   return JSON.parse(JSON.stringify(object));
 };
 
@@ -225,7 +224,7 @@ function hasEntryPointOrLoop(
         continue;
       }
 
-      const [hasEntry, _] = hasEntryPointOrLoop(typeMap, decodedType, decodedRelation, assignableRelation, visited);
+      const [hasEntry, ] = hasEntryPointOrLoop(typeMap, decodedType, decodedRelation, assignableRelation, visited);
       if (hasEntry) {
         return [true, false];
       }
@@ -276,7 +275,7 @@ function hasEntryPointOrLoop(
           continue;
         }
 
-        const [hasEntry, _] = hasEntryPointOrLoop(
+        const [hasEntry, ] = hasEntryPointOrLoop(
           typeMap,
           assignableType,
           computedRelationName,
@@ -673,7 +672,7 @@ function modelValidation(
   }
 
   for (const conditionName in authorizationModel.conditions) {
-    const condition = authorizationModel.conditions[conditionName];
+    // const condition = authorizationModel.conditions[conditionName];
     // Ensure that the nested condition name matches
     // TODO: This does not make sense for the DSL, and is a JSON only error
     // if (conditionName != condition.name) {


### PR DESCRIPTION
## Description

Currently we're not running eslint on any files, this changes that and fixes any issues that arise.

It also proposes a new structure for the make commands in JS:

* `make lint` - runs `npm run lint` and `npm run format:check`, both will run even if the other fails. This is now used in CI to check that there are no lint errors and no formatting issues
* `make format` runs `npm run lint:fix` and `npm run format:fix`, both will run even if the other fails. This is most likely best used locally on a dev machine to have eslint/prettier fix what they can and then we review what's left.

I leaned on the side of removing code rather than disabling rules, but happy to revert some changes if desired.

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
