### PR TITLE
chore: use folder syntax for gen folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-pkg/go/gen linguist-generated=true
-pkg/js/gen linguist-generated=true
+pkg/go/gen/* linguist-generated=true
+pkg/js/gen/* linguist-generated=true


### PR DESCRIPTION
## Description

I'm taking a stab in the dark on this one, after [searching through usage](https://github.com/search?q=%22linguist-generated%3Dtrue%22+language%3A%22Git+Attributes%22&type=code&l=Git+Attributes&p=2) on GitHub it seems that folders are listed using a `<path>/*` syntax so lets give that a try and see what happens?

## References

Closes #162 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
