### PR TITLE
Implement transforming `fga.mod`

### DIFF
--- a/pkg/go/.golangci.yaml
+++ b/pkg/go/.golangci.yaml
@@ -41,6 +41,7 @@ linters-settings:
           - github.com/openfga/api
           - google.golang.org/protobuf
           - github.com/openfga/language/pkg/go
+          - gopkg.in/yaml.v3
       test:
         files:
           - "$test"

--- a/pkg/go/transformer/mod-to-json.go
+++ b/pkg/go/transformer/mod-to-json.go
@@ -2,7 +2,6 @@ package transformer
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -76,8 +75,7 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Schema.Tag != stringNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg: fmt.Sprintf(
-				"unexpected schema type, expected string got %s value %s",
-				reflect.TypeOf(yamlModFile.Schema.Value),
+				"unexpected schema type, expected string got value %s",
 				yamlModFile.Schema.Value,
 			),
 			Line:   yamlModFile.Schema.Line - 1,
@@ -103,8 +101,7 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Module.Tag != stringNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg: fmt.Sprintf(
-				"unexpected module type, expected string got %s value %s",
-				reflect.TypeOf(yamlModFile.Module.Value),
+				"unexpected module type, expected string got value %s",
 				yamlModFile.Module.Value,
 			),
 			Line:   yamlModFile.Module.Line - 1,
@@ -124,8 +121,7 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Contents.Tag != seqNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg: fmt.Sprintf(
-				"unexpected contents type, expected list of strings got %s value %s",
-				reflect.TypeOf(yamlModFile.Contents.Value),
+				"unexpected contents type, expected list of strings got value %s",
 				yamlModFile.Contents.Value,
 			),
 			Line:   yamlModFile.Contents.Line - 1,
@@ -139,8 +135,7 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 			if file.Tag != stringNode {
 				errors = multierror.Append(errors, &ModFileValidationError{
 					Msg: fmt.Sprintf(
-						"unexpected contents item type, expected string got %s value %s",
-						reflect.TypeOf(file.Value),
+						"unexpected contents item type, expected string got value %s",
 						file.Value,
 					),
 					Line:   file.Line - 1,

--- a/pkg/go/transformer/mod-to-json.go
+++ b/pkg/go/transformer/mod-to-json.go
@@ -22,6 +22,8 @@ type YAMLModFile struct {
 
 type ModFileValidationErrorMetadata struct{}
 
+// ModFileValidationError is an error occurred during validation of the mod.fga file. Line and
+// column number provided are one based.
 type ModFileValidationError struct {
 	Line, Column int
 	Msg          string
@@ -54,6 +56,7 @@ const (
 	seqNode    = "!!seq"
 )
 
+// TransformModFile transforms a mod.fga and validates the fields are correct.
 func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	yamlModFile := &YAMLModFile{}
 
@@ -69,23 +72,20 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Schema.IsZero():
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "missing schema field",
-			Line:   0,
-			Column: 0,
+			Line:   1,
+			Column: 1,
 		})
 	case yamlModFile.Schema.Tag != stringNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
-			Msg: fmt.Sprintf(
-				"unexpected schema type, expected string got value %s",
-				yamlModFile.Schema.Value,
-			),
-			Line:   yamlModFile.Schema.Line - 1,
-			Column: yamlModFile.Schema.Column - 1,
+			Msg:    "unexpected schema type, expected string got value " + yamlModFile.Schema.Value,
+			Line:   yamlModFile.Schema.Line,
+			Column: yamlModFile.Schema.Column,
 		})
 	case yamlModFile.Schema.Value != "1.2":
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "unsupported schema version, fga.mod only supported in version `1.2`",
-			Line:   yamlModFile.Schema.Line - 1,
-			Column: yamlModFile.Schema.Column - 1,
+			Line:   yamlModFile.Schema.Line,
+			Column: yamlModFile.Schema.Column,
 		})
 	default:
 		modFile.Schema = yamlModFile.Schema.Value
@@ -95,17 +95,14 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Module.IsZero():
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "missing module field",
-			Line:   0,
-			Column: 0,
+			Line:   1,
+			Column: 1,
 		})
 	case yamlModFile.Module.Tag != stringNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
-			Msg: fmt.Sprintf(
-				"unexpected module type, expected string got value %s",
-				yamlModFile.Module.Value,
-			),
-			Line:   yamlModFile.Module.Line - 1,
-			Column: yamlModFile.Module.Column - 1,
+			Msg:    "unexpected module type, expected string got value " + yamlModFile.Module.Value,
+			Line:   yamlModFile.Module.Line,
+			Column: yamlModFile.Module.Column,
 		})
 	default:
 		modFile.Module = yamlModFile.Module.Value
@@ -115,17 +112,14 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Contents.IsZero():
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "missing contents field",
-			Line:   0,
-			Column: 0,
+			Line:   1,
+			Column: 1,
 		})
 	case yamlModFile.Contents.Tag != seqNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
-			Msg: fmt.Sprintf(
-				"unexpected contents type, expected list of strings got value %s",
-				yamlModFile.Contents.Value,
-			),
-			Line:   yamlModFile.Contents.Line - 1,
-			Column: yamlModFile.Contents.Column - 1,
+			Msg:    "unexpected contents type, expected list of strings got value " + yamlModFile.Contents.Value,
+			Line:   yamlModFile.Contents.Line,
+			Column: yamlModFile.Contents.Column,
 		})
 	default:
 		contents := []string{}
@@ -134,18 +128,15 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 
 			if file.Tag != stringNode {
 				errors = multierror.Append(errors, &ModFileValidationError{
-					Msg: fmt.Sprintf(
-						"unexpected contents item type, expected string got value %s",
-						file.Value,
-					),
-					Line:   file.Line - 1,
-					Column: file.Column - 1,
+					Msg:    "unexpected contents item type, expected string got value " + file.Value,
+					Line:   file.Line,
+					Column: file.Column,
 				})
 			} else if !strings.HasSuffix(file.Value, ".fga") {
 				errors = multierror.Append(errors, &ModFileValidationError{
 					Msg:    "contents items should use fga file extension, got " + file.Value,
-					Line:   file.Line - 1,
-					Column: file.Column - 1,
+					Line:   file.Line,
+					Column: file.Column,
 				})
 			}
 		}

--- a/pkg/go/transformer/mod-to-json.go
+++ b/pkg/go/transformer/mod-to-json.go
@@ -1,0 +1,168 @@
+package transformer
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"gopkg.in/yaml.v3"
+)
+
+type ModFile struct {
+	Schema   string   `json:"schema"`
+	Module   string   `json:"module"`
+	Contents []string `json:"contents"`
+}
+
+type YAMLModFile struct {
+	Schema   yaml.Node `yaml:"schema"`
+	Module   yaml.Node `yaml:"module"`
+	Contents yaml.Node `yaml:"contents"`
+}
+
+type ModFileValidationErrorMetadata struct{}
+
+type ModFileValidationError struct {
+	Line, Column int
+	Msg          string
+}
+
+func (e *ModFileValidationError) Error() string {
+	return fmt.Sprintf("validation error at line=%d, column=%d: %s", e.Line, e.Column, e.Msg)
+}
+
+type ModFileValidationMultipleError multierror.Error
+
+func (e *ModFileValidationMultipleError) Error() string {
+	errors := e.Errors
+
+	pluralS := ""
+	if len(errors) > 1 {
+		pluralS = "s"
+	}
+
+	errorsString := []string{}
+	for _, item := range errors {
+		errorsString = append(errorsString, item.Error())
+	}
+
+	return fmt.Sprintf("%d error%s occurred:\n\t* %s\n\n", len(errors), pluralS, strings.Join(errorsString, "\n\t* "))
+}
+
+const (
+	stringNode = "!!str"
+	seqNode    = "!!seq"
+)
+
+func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
+	yamlModFile := &YAMLModFile{}
+
+	err := yaml.Unmarshal([]byte(data), yamlModFile)
+	if err != nil {
+		return nil, err
+	}
+
+	modFile := &ModFile{}
+	errors := &multierror.Error{}
+
+	switch {
+	case yamlModFile.Schema.IsZero():
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg:    "missing schema field",
+			Line:   0,
+			Column: 0,
+		})
+	case yamlModFile.Schema.Tag != stringNode:
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg: fmt.Sprintf(
+				"unexpected schema type, expected string got %s value %s",
+				reflect.TypeOf(yamlModFile.Schema.Value),
+				yamlModFile.Schema.Value,
+			),
+			Line:   yamlModFile.Schema.Line - 1,
+			Column: yamlModFile.Schema.Column - 1,
+		})
+	case yamlModFile.Schema.Value != "1.2":
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg:    "unsupported schema version, fga.mod only supported in version `1.2`",
+			Line:   yamlModFile.Schema.Line - 1,
+			Column: yamlModFile.Schema.Column - 1,
+		})
+	default:
+		modFile.Schema = yamlModFile.Schema.Value
+	}
+
+	switch {
+	case yamlModFile.Module.IsZero():
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg:    "missing module field",
+			Line:   0,
+			Column: 0,
+		})
+	case yamlModFile.Module.Tag != stringNode:
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg: fmt.Sprintf(
+				"unexpected module type, expected string got %s value %s",
+				reflect.TypeOf(yamlModFile.Module.Value),
+				yamlModFile.Module.Value,
+			),
+			Line:   yamlModFile.Module.Line - 1,
+			Column: yamlModFile.Module.Column - 1,
+		})
+	default:
+		modFile.Module = yamlModFile.Module.Value
+	}
+
+	switch {
+	case yamlModFile.Contents.IsZero():
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg:    "missing contents field",
+			Line:   0,
+			Column: 0,
+		})
+	case yamlModFile.Contents.Tag != seqNode:
+		errors = multierror.Append(errors, &ModFileValidationError{
+			Msg: fmt.Sprintf(
+				"unexpected contents type, expected list of strings got %s value %s",
+				reflect.TypeOf(yamlModFile.Contents.Value),
+				yamlModFile.Contents.Value,
+			),
+			Line:   yamlModFile.Contents.Line - 1,
+			Column: yamlModFile.Contents.Column - 1,
+		})
+	default:
+		contents := []string{}
+		for _, file := range yamlModFile.Contents.Content {
+			contents = append(contents, file.Value)
+
+			if file.Tag != stringNode {
+				errors = multierror.Append(errors, &ModFileValidationError{
+					Msg: fmt.Sprintf(
+						"unexpected contents item type, expected string got %s value %s",
+						reflect.TypeOf(file.Value),
+						file.Value,
+					),
+					Line:   file.Line - 1,
+					Column: file.Column - 1,
+				})
+			} else if !strings.HasSuffix(file.Value, ".fga") {
+				errors = multierror.Append(errors, &ModFileValidationError{
+					Msg:    "contents items should use fga file extension, got " + file.Value,
+					Line:   file.Line - 1,
+					Column: file.Column - 1,
+				})
+			}
+		}
+
+		modFile.Contents = contents
+	}
+
+	if len(errors.Errors) != 0 {
+		return nil, &ModFileValidationMultipleError{
+			Errors: errors.Errors,
+		}
+	}
+
+	return modFile, nil
+}

--- a/pkg/go/transformer/mod-to-json_test.go
+++ b/pkg/go/transformer/mod-to-json_test.go
@@ -51,9 +51,10 @@ func TestModFileToJSONTransformer(t *testing.T) {
 					}
 				}
 			} else {
+				require.NoError(t, err)
+
 				expected := &transformer.ModFile{}
 				err = json.Unmarshal([]byte(testCase.JSON), expected)
-				require.NoError(t, err)
 				require.NoError(t, err)
 				require.Equal(t, expected, actual)
 			}

--- a/pkg/go/transformer/mod-to-json_test.go
+++ b/pkg/go/transformer/mod-to-json_test.go
@@ -1,0 +1,83 @@
+package transformer_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openfga/language/pkg/go/transformer"
+)
+
+func TestModFileToJSONTransformer(t *testing.T) {
+	t.Parallel()
+
+	testCases, err := loadModFileTestCases()
+	require.NoError(t, err)
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.Skip {
+				t.Skip()
+			}
+
+			actual, err := transformer.TransformModFile(testCase.ModFile)
+
+			if len(testCase.ExpectedErrors) != 0 {
+				require.Error(t, err)
+
+				pluralS := ""
+				if len(testCase.ExpectedErrors) > 1 {
+					pluralS = "s"
+				}
+
+				errorsString := []string{}
+				for _, err := range testCase.ExpectedErrors {
+					errorsString = append(
+						errorsString,
+						fmt.Sprintf("validation error at line=%d, column=%d: %s", err.Line.Start, err.Column.Start, err.Msg),
+					)
+				}
+
+				errorMessage := fmt.Sprintf(
+					"%d error%s occurred:\n\t* %s\n\n",
+					len(testCase.ExpectedErrors),
+					pluralS,
+					strings.Join(errorsString, "\n\t*"),
+				)
+
+				assert.Equal(t, errorMessage, err.Error())
+
+				var verr *transformer.ModFileValidationMultipleError
+				if errors.As(err, &verr) {
+					errors := verr.Errors
+
+					for i := 0; i < len(testCase.ExpectedErrors); i++ {
+						errorDetails := testCase.ExpectedErrors[i]
+						expected := errors[i]
+						actual := &transformer.ModFileValidationError{
+							Line:   errorDetails.Line.Start,
+							Column: errorDetails.Column.Start,
+							Msg:    errorDetails.Msg,
+						}
+
+						assert.Equal(t, expected, actual)
+					}
+				}
+			} else {
+				expected := &transformer.ModFile{}
+				err = json.Unmarshal([]byte(testCase.JSON), expected)
+				require.NoError(t, err)
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/go/transformer/mod-to-json_test.go
+++ b/pkg/go/transformer/mod-to-json_test.go
@@ -3,8 +3,6 @@ package transformer_test
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,26 +31,7 @@ func TestModFileToJSONTransformer(t *testing.T) {
 			if len(testCase.ExpectedErrors) != 0 {
 				require.Error(t, err)
 
-				pluralS := ""
-				if len(testCase.ExpectedErrors) > 1 {
-					pluralS = "s"
-				}
-
-				errorsString := []string{}
-				for _, err := range testCase.ExpectedErrors {
-					errorsString = append(
-						errorsString,
-						fmt.Sprintf("validation error at line=%d, column=%d: %s", err.Line.Start, err.Column.Start, err.Msg),
-					)
-				}
-
-				errorMessage := fmt.Sprintf(
-					"%d error%s occurred:\n\t* %s\n\n",
-					len(testCase.ExpectedErrors),
-					pluralS,
-					strings.Join(errorsString, "\n\t*"),
-				)
-
+				errorMessage := testCase.GetErrorString()
 				assert.Equal(t, errorMessage, err.Error())
 
 				var verr *transformer.ModFileValidationMultipleError

--- a/pkg/go/transformer/testcases_test.go
+++ b/pkg/go/transformer/testcases_test.go
@@ -127,3 +127,23 @@ func loadInvalidJSONSyntaxTestCases() ([]invalidJSONSyntaxTestCase, error) {
 
 	return testCases, err //nolint:wrapcheck
 }
+
+type fgdModFileTestCase struct {
+	Name           string          `json:"name"            yaml:"name"`
+	ModFile        string          `json:"modFile"         yaml:"modFile"` //nolint:tagliatelle
+	JSON           string          `json:"json"            yaml:"json"`
+	Skip           bool            `json:"skip"            yaml:"skip"`
+	ExpectedErrors []expectedError `json:"expected_errors" yaml:"expected_errors"`
+}
+
+func loadModFileTestCases() ([]fgdModFileTestCase, error) {
+	data, err := os.ReadFile(filepath.Join("../../../tests", "data", "fga-mod-transformer-cases.yaml"))
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+
+	testCases := []fgdModFileTestCase{}
+	err = yaml.Unmarshal(data, &testCases)
+
+	return testCases, err //nolint:wrapcheck
+}

--- a/pkg/go/transformer/testcases_test.go
+++ b/pkg/go/transformer/testcases_test.go
@@ -136,6 +136,28 @@ type fgdModFileTestCase struct {
 	ExpectedErrors []expectedError `json:"expected_errors" yaml:"expected_errors"`
 }
 
+func (testCase *fgdModFileTestCase) GetErrorString() string {
+	pluralS := ""
+	if len(testCase.ExpectedErrors) > 1 {
+		pluralS = "s"
+	}
+
+	errorsString := []string{}
+	for _, err := range testCase.ExpectedErrors {
+		errorsString = append(
+			errorsString,
+			fmt.Sprintf("validation error at line=%d, column=%d: %s", err.Line.Start, err.Column.Start, err.Msg),
+		)
+	}
+
+	return fmt.Sprintf(
+		"%d error%s occurred:\n\t* %s\n\n",
+		len(testCase.ExpectedErrors),
+		pluralS,
+		strings.Join(errorsString, "\n\t* "),
+	)
+}
+
 func loadModFileTestCases() ([]fgdModFileTestCase, error) {
 	data, err := os.ReadFile(filepath.Join("../../../tests", "data", "fga-mod-transformer-cases.yaml"))
 	if err != nil {

--- a/pkg/js/errors.ts
+++ b/pkg/js/errors.ts
@@ -175,7 +175,7 @@ export class ConditionNameDoesntMatchError extends Error {
 
 /**
  * Represents an individual error returned during validation of `fga.mod`.
- * Line and column numbers returned as part of this are zero based,
+ * Line and column numbers returned as part of this are one based,
  */
 export class FGAModFileValidationSingleError extends BaseError {
   constructor(

--- a/pkg/js/errors.ts
+++ b/pkg/js/errors.ts
@@ -171,3 +171,34 @@ export class ConditionNameDoesntMatchError extends Error {
     super(`the '${conditionName}' condition has a different nested condition name ('${conditionNestedName}')`);
   }
 }
+
+
+/**
+ * Represents an individual error returned during validation of `fga.mod`.
+ * Line and column numbers returned as part of this are zero based,
+ */
+export class FGAModFileValidationSingleError extends BaseError {
+  constructor(
+    public properties: ErrorProperties,
+  ) {
+    super(properties, "validation");
+  }
+
+  toString() {
+    return this.message;
+  }
+}
+
+/**
+ * Thrown when an `fga.mod` file is invalid
+ */
+export class FGAModFileValidationError extends Error {
+  constructor(public errors: FGAModFileValidationSingleError[]) {
+    super(`${errors.length} error${errors.length > 1 ? "s" : ""} occurred:\n\t* ${errors.join("\n\t* ")}\n\n`);
+    this.errors = errors;
+  }
+
+  toString() {
+    return this.message;
+  }
+}

--- a/pkg/js/package-lock.json
+++ b/pkg/js/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.2.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "antlr4": "^4.13.1"
+        "antlr4": "^4.13.1",
+        "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@openfga/sdk": "^0.3.0",
         "@types/jest": "^29.5.11",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
@@ -25,8 +25,7 @@
         "jest-html-reporter": "^3.10.2",
         "prettier": "^3.2.4",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.3.3",
-        "yaml": "^2.3.4"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -747,6 +746,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -756,6 +771,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1423,12 +1444,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1692,22 +1707,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2849,6 +2848,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2858,6 +2873,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -4555,12 +4576,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6214,7 +6229,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }

--- a/pkg/js/package.json
+++ b/pkg/js/package.json
@@ -30,12 +30,12 @@
   ],
   "author": "OpenFGA",
   "dependencies": {
-    "antlr4": "^4.13.1"
+    "antlr4": "^4.13.1",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@openfga/sdk": "^0.3.0",
     "@types/jest": "^29.5.11",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.11.5",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
@@ -46,8 +46,7 @@
     "jest-html-reporter": "^3.10.2",
     "prettier": "^3.2.4",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.3.3",
-    "yaml": "^2.3.4"
+    "typescript": "^5.3.3"
   },
   "files": [
     "README.md",

--- a/pkg/js/tests/_testcases.ts
+++ b/pkg/js/tests/_testcases.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as yaml from "yaml";
-import { DSLSyntaxSingleError, ModelValidationSingleError } from "../errors";
+import { DSLSyntaxSingleError, FGAModFileValidationSingleError, ModelValidationSingleError } from "../errors";
 
 interface ValidTestCase {
   name: string;
@@ -30,6 +30,11 @@ interface MultipleInvalidDSLSyntaxTestCase extends InvalidDSLSyntaxTestCase {
 
 interface MultipleInvalidTestCase extends InvalidDSLSyntaxTestCase {
   expected_errors: ModelValidationSingleError[];
+}
+
+interface FGAModFileTestCase extends Omit<ValidTestCase, "dsl"> {
+  modFile: string;
+  expected_errors?: FGAModFileValidationSingleError[];
 }
 
 export function loadValidTransformerTestCases(): ValidTestCase[] {
@@ -87,4 +92,10 @@ export function loadInvalidJSONSyntaxTestCases(): InvalidJSONSyntaxTestCase[] {
       "utf-8",
     ),
   ) as InvalidJSONSyntaxTestCase[];
+}
+
+export function loadModFileTestCases(): FGAModFileTestCase[] {
+  return yaml.parse(
+    fs.readFileSync(path.join(__dirname, "../../../tests", "data", "fga-mod-transformer-cases.yaml"), "utf-8"),
+  ) as FGAModFileTestCase[];
 }

--- a/pkg/js/tests/modules/mod-to-json.test.ts
+++ b/pkg/js/tests/modules/mod-to-json.test.ts
@@ -1,0 +1,38 @@
+import { FGAModFileValidationError, FGAModFileValidationSingleError } from "../../errors";
+import { transformModFileToJSON } from "../../transformer/modules/mod-to-json";
+import { loadModFileTestCases } from "../_testcases";
+
+describe("modFileToJSON", () => {
+
+    const testCases = loadModFileTestCases();
+
+    testCases.forEach((testCase) => {
+        const testFn = testCase.skip ? it.skip : it;
+        testFn(`transformModFileToJSON ${testCase.name}`, () => {
+            if (!testCase.expected_errors) {
+                expect(transformModFileToJSON(testCase.modFile)).toEqual(JSON.parse(testCase.json));
+            } else {
+                expect(() => transformModFileToJSON(testCase.modFile)).toThrow(FGAModFileValidationError);
+                try {
+                    transformModFileToJSON(testCase.modFile);
+                } catch (error) {
+                    const exception = error as FGAModFileValidationError;
+                    if (testCase.expected_errors) {
+                        const errorsCount = testCase.expected_errors.length;
+                        expect(exception.message).toEqual(
+                          `${errorsCount} error${errorsCount === 1 ? "" : "s"} occurred:\n\t* ${testCase.expected_errors
+                            .map((err: FGAModFileValidationSingleError) => {
+                              return `validation error at line=${err.line?.start}, column=${err.column?.start}: ${err.msg}`;
+                            })
+                            .join("\n\t* ")}\n\n`,
+                        );
+
+                        for (let index = 0; index < errorsCount; index++) {
+                          expect(exception.errors[index]).toMatchObject(testCase.expected_errors[index]);
+                        }
+                      }
+                }
+            }
+        });
+    });
+});

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -1,0 +1,172 @@
+import { parseDocument, LineCounter, Scalar, isSeq, isNode, YAMLSeq } from "yaml";
+import { LinePos } from "yaml/dist/errors";
+import { FGAModFileValidationError, FGAModFileValidationSingleError } from "../../errors";
+/**
+ * An `fga.mod` file represented as JSON
+ */
+export interface ModFile {
+  /**
+   * The schema version. This currently will only be 1.2
+   */
+  schema: string
+  /**
+   * The module name.
+   */
+  module: string
+  /**
+   * The individual files that make up the modular model.
+   */
+  contents: string[]
+}
+
+/**
+ * Gets the line and column data from the `linePos` returned from parsing a yaml file.
+ * @param linePos - The `linePos` property.
+ * @returns Line and column data.
+ */
+function getLineAndColumnFromLinePos(
+  linePos?: [LinePos] | [LinePos, LinePos]
+): { line: { start: number; end: number; }, column: { start: number; end: number; }} {
+  if (linePos === undefined) {
+    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
+  }
+  // eslint-disable-next-line prefer-const
+  let [start, end] = linePos;
+  if (end === undefined) {
+    end = start;
+  }
+  return {
+    line: {
+      start: start.line - 1,
+      end: end.line - 1
+    },
+    column: {
+      start: start.col - 1,
+      end: end.col - 1
+    }
+  };
+}
+
+/**
+ * Gets the line and column data for a node in a yaml doc.
+ * @param node - The node from the yaml doc.
+ * @param counter - The instance of LineCounter that was passed to `parseDocument`.
+ * @returns Line and column data.
+ */
+function getLineAndColumnFromNode(
+  node: unknown,
+  counter: LineCounter
+): { line: { start: number; end: number; }, column: { start: number; end: number; }} {
+  if (!isNode(node) || !node.range) {
+    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
+  }
+
+  const start = counter.linePos(node.range[0]);
+  const end = counter.linePos(node.range[1]);
+  return {
+    line: {
+      start: start.line - 1,
+      end: end.line - 1
+    },
+    column: {
+      start: start.col - 1,
+      end: end.col - 1
+    }
+  };
+}
+
+/**
+ * Transforms an `fga.mod` file into the JSON representation and validate the fields are correct.
+ * @param {string} modFile - The `fga.mod` file
+ * @returns {ModFile} The jSON representation of the `fga.mod` file.
+ */
+export const transformModFileToJSON = (modFile: string): ModFile => {
+  const lineCounter = new LineCounter();
+  const yamlDoc = parseDocument(modFile, {
+    lineCounter,
+    keepSourceTokens: true
+  });
+
+  const errors: FGAModFileValidationSingleError[] = [];
+  // Copy over any general yaml parsing errors
+  for (const error of yamlDoc.errors) {
+    errors.push(new FGAModFileValidationSingleError({
+      msg: error.message,
+      ...getLineAndColumnFromLinePos(error.linePos)
+    }));
+  }
+
+  if (!yamlDoc.has("schema")) {
+    errors.push(new FGAModFileValidationSingleError({
+      msg: "missing schema field",
+      ...getLineAndColumnFromLinePos()
+    }));
+  } else {
+    const schema = yamlDoc.get("schema");
+    if (typeof schema !== "string") {
+      const node = yamlDoc.getIn(["schema"], true);
+
+      errors.push(new FGAModFileValidationSingleError({
+        msg: `unexpected schema type, expected string got ${typeof schema} value ${schema}`,
+        ...getLineAndColumnFromNode(node, lineCounter)
+      }));
+    } else if (schema !== "1.2") {
+      const node = yamlDoc.getIn(["schema"], true);
+      errors.push(new FGAModFileValidationSingleError({
+        msg: "unsupported schema version, fga.mod only supported in version `1.2`",
+        ...getLineAndColumnFromNode(node, lineCounter)
+      }));
+    }
+  }
+
+  if (!yamlDoc.has("module")) {
+    errors.push(new FGAModFileValidationSingleError({
+      msg: "missing module field",
+      ...getLineAndColumnFromLinePos()
+    }));
+  } else if (typeof yamlDoc.get("module") !== "string") {
+    const node = yamlDoc.getIn(["module"], true);
+    errors.push(new FGAModFileValidationSingleError({
+      msg: `unexpected module type, expected string got ${typeof yamlDoc.get("module")} value ${yamlDoc.get("module")}`,
+      ...getLineAndColumnFromNode(node, lineCounter)
+    }));
+  }
+
+  if (!yamlDoc.has("contents")) {
+    errors.push(new FGAModFileValidationSingleError({
+      msg: "missing contents field",
+      ...getLineAndColumnFromLinePos()
+    }));
+  } else if (!isSeq(yamlDoc.get("contents"))) {
+    const node = yamlDoc.getIn(["contents"], true);
+    const contents = yamlDoc.get("contents");
+    errors.push(new FGAModFileValidationSingleError({
+      msg: `unexpected contents type, expected list of strings got ${typeof contents} value ${contents}`,
+      ...getLineAndColumnFromNode(node, lineCounter)
+    }));
+  } else {
+    const contents = yamlDoc.get("contents") as YAMLSeq<Scalar>;
+    for (const file of contents.items) {
+      if (typeof file.value !== "string") {
+        errors.push(new FGAModFileValidationSingleError({
+          msg: `unexpected contents item type, expected string got ${typeof file.value} value ${file.value}`,
+          ...getLineAndColumnFromNode(file, lineCounter)
+        }));
+        continue;
+      }
+
+      if (!file.value.endsWith(".fga")) {
+        errors.push(new FGAModFileValidationSingleError({
+          msg: `contents items should use fga file extension, got ${file.value}`,
+          ...getLineAndColumnFromNode(file, lineCounter)
+        }));
+      }
+    }
+  }
+
+  if (errors.length) {
+    throw new FGAModFileValidationError(errors);
+  }
+
+  return yamlDoc.toJSON();
+};

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -107,7 +107,7 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
       const node = yamlDoc.getIn(["schema"], true);
 
       errors.push(new FGAModFileValidationSingleError({
-        msg: `unexpected schema type, expected string got ${typeof schema} value ${schema}`,
+        msg: `unexpected schema type, expected string got value ${schema}`,
         ...getLineAndColumnFromNode(node, lineCounter)
       }));
     } else if (schema !== "1.2") {
@@ -127,7 +127,7 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
   } else if (typeof yamlDoc.get("module") !== "string") {
     const node = yamlDoc.getIn(["module"], true);
     errors.push(new FGAModFileValidationSingleError({
-      msg: `unexpected module type, expected string got ${typeof yamlDoc.get("module")} value ${yamlDoc.get("module")}`,
+      msg: `unexpected module type, expected string got value ${yamlDoc.get("module")}`,
       ...getLineAndColumnFromNode(node, lineCounter)
     }));
   }
@@ -141,7 +141,7 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
     const node = yamlDoc.getIn(["contents"], true);
     const contents = yamlDoc.get("contents");
     errors.push(new FGAModFileValidationSingleError({
-      msg: `unexpected contents type, expected list of strings got ${typeof contents} value ${contents}`,
+      msg: `unexpected contents type, expected list of strings got value ${contents}`,
       ...getLineAndColumnFromNode(node, lineCounter)
     }));
   } else {
@@ -149,7 +149,7 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
     for (const file of contents.items) {
       if (typeof file.value !== "string") {
         errors.push(new FGAModFileValidationSingleError({
-          msg: `unexpected contents item type, expected string got ${typeof file.value} value ${file.value}`,
+          msg: `unexpected contents item type, expected string got value ${file.value}`,
           ...getLineAndColumnFromNode(file, lineCounter)
         }));
         continue;

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -28,7 +28,7 @@ function getLineAndColumnFromLinePos(
   linePos?: [LinePos] | [LinePos, LinePos]
 ): { line: { start: number; end: number; }, column: { start: number; end: number; }} {
   if (linePos === undefined) {
-    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
+    return { line: { start: 1, end: 1 }, column: { start: 1, end: 1 } };
   }
   // eslint-disable-next-line prefer-const
   let [start, end] = linePos;
@@ -37,12 +37,12 @@ function getLineAndColumnFromLinePos(
   }
   return {
     line: {
-      start: start.line - 1,
-      end: end.line - 1
+      start: start.line ,
+      end: end.line
     },
     column: {
-      start: start.col - 1,
-      end: end.col - 1
+      start: start.col,
+      end: end.col
     }
   };
 }
@@ -58,19 +58,19 @@ function getLineAndColumnFromNode(
   counter: LineCounter
 ): { line: { start: number; end: number; }, column: { start: number; end: number; }} {
   if (!isNode(node) || !node.range) {
-    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
+    return { line: { start: 1, end: 1 }, column: { start: 1, end: 1 } };
   }
 
   const start = counter.linePos(node.range[0]);
   const end = counter.linePos(node.range[1]);
   return {
     line: {
-      start: start.line - 1,
-      end: end.line - 1
+      start: start.line,
+      end: end.line
     },
     column: {
-      start: start.col - 1,
-      end: end.col - 1
+      start: start.col ,
+      end: end.col
     }
   };
 }

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -1,0 +1,145 @@
+---
+- name: valid syntax
+  modFile: |
+    schema: '1.2'
+    module: acme
+    contents:
+      - core.fga
+      - team1/project.fga
+      - team1/board.fga
+      - wiki.fga
+  json: |
+    {
+      "schema": "1.2",
+      "module": "acme",
+      "contents": ["core.fga", "team1/project.fga", "team1/board.fga", "wiki.fga"]
+    }
+- name: missing schema
+  modFile: |
+    module: acme
+    contents:
+      - core.fga
+  expected_errors:
+    - msg: missing schema field
+      line:
+        start: 0
+        end: 0
+      column:
+        start: 0
+        end: 0
+- name: invalid schema type
+  modFile: |
+    schema: true
+    module: acme
+    contents:
+      - core.fga
+  expected_errors:
+    - msg: unexpected schema type, expected string got boolean value true
+      line:
+        start: 0
+        end: 0
+      column:
+        start: 8
+        end: 12
+- name: invalid schema version
+  modFile: |
+    schema: "1.1"
+    module: acme
+    contents:
+      - core.fga
+  expected_errors:
+    - msg: unsupported schema version, fga.mod only supported in version `1.2`
+      line:
+        start: 0
+        end: 0
+      column:
+        start: 8
+        end: 13
+- name: missing module
+  modFile: |
+    schema: "1.2"
+    contents:
+      - core.fga
+  expected_errors:
+    - msg: missing module field
+      line:
+        start: 0
+        end: 0
+      column:
+        start: 0
+        end: 0
+- name: invalid module type
+  modFile: |
+    schema: "1.2"
+    module: true
+    contents:
+      - core.fga
+  expected_errors:
+    - msg: unexpected module type, expected string got boolean value true
+      line:
+        start: 1
+        end: 1
+      column:
+        start: 8
+        end: 12
+- name: missing contents
+  modFile: |
+    schema: "1.2"
+    module: acme
+  expected_errors:
+    - msg: missing contents field
+      line:
+        start: 0
+        end: 0
+      column:
+        start: 0
+        end: 0
+- name: invalid contents type
+  modFile: |
+    schema: "1.2"
+    module: acme
+    contents: true
+  expected_errors:
+    - msg: unexpected contents type, expected list of strings got boolean value true
+      line:
+        start: 2
+        end: 2
+      column:
+        start: 10
+        end: 14
+- name: contents is not a list of strings
+  modFile: |
+    schema: "1.2"
+    module: acme
+    contents:
+      - true
+      - 1
+  expected_errors:
+    - msg: unexpected contents item type, expected string got boolean value true
+      line:
+        start: 3
+        end: 3
+      column:
+        start: 4
+        end: 8
+    - msg: unexpected contents item type, expected string got number value 1
+      line:
+        start: 4
+        end: 4
+      column:
+        start: 4
+        end: 5
+- name: contents item does not end with `.fga`
+  modFile: |
+    schema: "1.2"
+    module: acme
+    contents:
+      - core.txt
+  expected_errors:
+    - msg: contents items should use fga file extension, got core.txt
+      line:
+        start: 3
+        end: 3
+      column:
+        start: 4
+        end: 12

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -34,7 +34,7 @@
     contents:
       - core.fga
   expected_errors:
-    - msg: unexpected schema type, expected string got boolean value true
+    - msg: unexpected schema type, expected string got value true
       line:
         start: 0
         end: 0
@@ -75,7 +75,7 @@
     contents:
       - core.fga
   expected_errors:
-    - msg: unexpected module type, expected string got boolean value true
+    - msg: unexpected module type, expected string got value true
       line:
         start: 1
         end: 1
@@ -100,7 +100,7 @@
     module: acme
     contents: true
   expected_errors:
-    - msg: unexpected contents type, expected list of strings got boolean value true
+    - msg: unexpected contents type, expected list of strings got value true
       line:
         start: 2
         end: 2
@@ -115,14 +115,14 @@
       - true
       - 1
   expected_errors:
-    - msg: unexpected contents item type, expected string got boolean value true
+    - msg: unexpected contents item type, expected string got value true
       line:
         start: 3
         end: 3
       column:
         start: 4
         end: 8
-    - msg: unexpected contents item type, expected string got number value 1
+    - msg: unexpected contents item type, expected string got value 1
       line:
         start: 4
         end: 4

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -22,11 +22,11 @@
   expected_errors:
     - msg: missing schema field
       line:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
       column:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
 - name: invalid schema type
   modFile: |
     schema: true
@@ -36,11 +36,11 @@
   expected_errors:
     - msg: unexpected schema type, expected string got value true
       line:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
       column:
-        start: 8
-        end: 12
+        start: 9
+        end: 13
 - name: invalid schema version
   modFile: |
     schema: "1.1"
@@ -50,11 +50,11 @@
   expected_errors:
     - msg: unsupported schema version, fga.mod only supported in version `1.2`
       line:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
       column:
-        start: 8
-        end: 13
+        start: 9
+        end: 14
 - name: missing module
   modFile: |
     schema: "1.2"
@@ -63,11 +63,11 @@
   expected_errors:
     - msg: missing module field
       line:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
       column:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
 - name: invalid module type
   modFile: |
     schema: "1.2"
@@ -77,11 +77,11 @@
   expected_errors:
     - msg: unexpected module type, expected string got value true
       line:
-        start: 1
-        end: 1
+        start: 2
+        end: 2
       column:
-        start: 8
-        end: 12
+        start: 9
+        end: 13
 - name: missing contents
   modFile: |
     schema: "1.2"
@@ -89,11 +89,11 @@
   expected_errors:
     - msg: missing contents field
       line:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
       column:
-        start: 0
-        end: 0
+        start: 1
+        end: 1
 - name: invalid contents type
   modFile: |
     schema: "1.2"
@@ -102,11 +102,11 @@
   expected_errors:
     - msg: unexpected contents type, expected list of strings got value true
       line:
-        start: 2
-        end: 2
+        start: 3
+        end: 3
       column:
-        start: 10
-        end: 14
+        start: 11
+        end: 15
 - name: contents is not a list of strings
   modFile: |
     schema: "1.2"
@@ -117,18 +117,18 @@
   expected_errors:
     - msg: unexpected contents item type, expected string got value true
       line:
-        start: 3
-        end: 3
-      column:
-        start: 4
-        end: 8
-    - msg: unexpected contents item type, expected string got value 1
-      line:
         start: 4
         end: 4
       column:
-        start: 4
+        start: 5
+        end: 9
+    - msg: unexpected contents item type, expected string got value 1
+      line:
+        start: 5
         end: 5
+      column:
+        start: 5
+        end: 6
 - name: contents item does not end with `.fga`
   modFile: |
     schema: "1.2"
@@ -138,8 +138,8 @@
   expected_errors:
     - msg: contents items should use fga file extension, got core.txt
       line:
-        start: 3
-        end: 3
-      column:
         start: 4
-        end: 12
+        end: 4
+      column:
+        start: 5
+        end: 13


### PR DESCRIPTION
## Description

Adds test cases for transforming and validating an `fga.mod` file and then implements the function for JS. Currently working on Go and will move to ready once completed. Just putting up the PR now to get a review of the JS side ahead of then.

The `transformModFileToJSON` function will take a string representing a `fga.mod` file, parse it and then validate the fields inside. Given that this is isn't a complex file I've decided to just go checking ourselves rather than offloading onto a package like `ajv` to perform JSON Schema validation.

All error cases and messages are up for discussion, I'm not particularly married to them just tried to hit most I could think of.

I still need to add test cases for invalid yaml file (if that's possible to do inside our YAML test definition file 🤔  )

There's maybe some contention around this living alongside the existing transform functions but also implementing validation. I'm not sure if we can extend this to a transform/validate function similar to others however due to the requirement on the yaml document when validating.

## References

Closes #154

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
