### PR TITLE
feat: change transformModFileToJSON to return line and column information

### DIFF
--- a/pkg/go/transformer/mod-to-json_test.go
+++ b/pkg/go/transformer/mod-to-json_test.go
@@ -1,7 +1,6 @@
 package transformer_test
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -53,10 +52,9 @@ func TestModFileToJSONTransformer(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				expected := &transformer.ModFile{}
-				err = json.Unmarshal([]byte(testCase.JSON), expected)
-				require.NoError(t, err)
-				require.Equal(t, expected, actual)
+				assert.NotNil(t, actual.Schema.Value)
+				assert.NotNil(t, actual.Module.Value)
+				assert.NotNil(t, actual.Contents.Value)
 			}
 		})
 	}

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -126,61 +126,55 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
 
   const parsedModFile: Partial<ModFile> = {};
 
-  if (!yamlDoc.has("schema")) {
+  const schemaNode = yamlDoc.get("schema", true) as Scalar<string>;
+  if (!schemaNode) {
     errors.push(new FGAModFileValidationSingleError({
       msg: "missing schema field",
       ...getLineAndColumnFromLinePos()
     }));
-  } else if (typeof yamlDoc.get("schema") !== "string") {
-    const node = yamlDoc.getIn(["schema"], true);
-
+  } else if (typeof schemaNode.value !== "string") {
     errors.push(new FGAModFileValidationSingleError({
-      msg: `unexpected schema type, expected string got value ${yamlDoc.get("schema")}`,
-      ...getLineAndColumnFromNode(node, lineCounter)
+      msg: `unexpected schema type, expected string got value ${schemaNode.value}`,
+      ...getLineAndColumnFromNode(schemaNode, lineCounter)
     }));
-  } else if (yamlDoc.get("schema") !== "1.2") {
-    const node = yamlDoc.getIn(["schema"], true);
+  } else if (schemaNode.value !== "1.2") {
     errors.push(new FGAModFileValidationSingleError({
       msg: "unsupported schema version, fga.mod only supported in version `1.2`",
-      ...getLineAndColumnFromNode(node, lineCounter)
+      ...getLineAndColumnFromNode(schemaNode, lineCounter)
     }));
   } else {
-    const node = yamlDoc.getIn(["schema"], true);
     parsedModFile.schema = {
-      //@ts-expect-error
-      value: node.value,
-      ...getLineAndColumnFromNode(node, lineCounter)
+      value: schemaNode.value,
+      ...getLineAndColumnFromNode(schemaNode, lineCounter)
     };
   }
 
-
-  if (!yamlDoc.has("module")) {
+  const moduleNode = yamlDoc.get("module", true) as Scalar<string>;
+  if (!moduleNode) {
     errors.push(new FGAModFileValidationSingleError({
       msg: "missing module field",
       ...getLineAndColumnFromLinePos()
     }));
-  } else if (typeof yamlDoc.get("module") !== "string") {
-    const node = yamlDoc.getIn(["module"], true);
+  } else if (typeof moduleNode.value !== "string") {
     errors.push(new FGAModFileValidationSingleError({
-      msg: `unexpected module type, expected string got value ${yamlDoc.get("module")}`,
-      ...getLineAndColumnFromNode(node, lineCounter)
+      msg: `unexpected module type, expected string got value ${moduleNode.value}`,
+      ...getLineAndColumnFromNode(moduleNode, lineCounter)
     }));
   } else {
-    const node = yamlDoc.getIn(["module"], true);
     parsedModFile.module = {
-      //@ts-expect-error
-      value: node.value,
-      ...getLineAndColumnFromNode(node, lineCounter)
+      value: moduleNode.value,
+      ...getLineAndColumnFromNode(moduleNode, lineCounter)
     };
   }
 
-  if (!yamlDoc.has("contents")) {
+  const contentsNode = yamlDoc.get("contents", true) as YAMLSeq<Scalar>;
+  if (!contentsNode) {
     errors.push(new FGAModFileValidationSingleError({
       msg: "missing contents field",
       ...getLineAndColumnFromLinePos()
     }));
-  } else if (!isSeq(yamlDoc.get("contents"))) {
-    const node = yamlDoc.getIn(["contents"], true);
+  } else if (!isSeq(contentsNode)) {
+    const node = yamlDoc.get("contents", true);
     const contents = yamlDoc.get("contents");
     errors.push(new FGAModFileValidationSingleError({
       msg: `unexpected contents type, expected list of strings got value ${contents}`,
@@ -211,7 +205,7 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
         ...getLineAndColumnFromNode(file, lineCounter)
       });
     }
-    const node = yamlDoc.getIn(["contents"], true);
+    const node = yamlDoc.get("contents", true);
     parsedModFile.contents = {
       value: contentsValue,
       ...getLineAndColumnFromNode(node, lineCounter)

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -10,9 +10,84 @@
       - wiki.fga
   json: |
     {
-      "schema": "1.2",
-      "module": "acme",
-      "contents": ["core.fga", "team1/project.fga", "team1/board.fga", "wiki.fga"]
+      "schema": {
+        "value": "1.2",
+        "line": {
+          "start": 1,
+          "end": 1
+        },
+        "column": {
+          "start": 9,
+          "end": 14
+        }
+      },
+      "module":{
+        "value": "acme",
+        "line": {
+          "start": 2,
+          "end": 2
+        },
+        "column": {
+          "start": 9,
+          "end": 13
+        }
+      },
+      "contents": {
+        "value": [
+          {
+            "value": "core.fga",
+            "line": {
+              "start": 4,
+              "end": 4
+            },
+            "column": {
+              "start": 5,
+              "end": 13
+            }
+          },
+          {
+            "value": "team1/project.fga",
+            "line": {
+              "start": 5,
+              "end": 5
+            },
+            "column": {
+              "start": 5,
+              "end": 22
+            }
+          },
+          {
+            "value": "team1/board.fga",
+            "line": {
+              "start": 6,
+              "end": 6
+            },
+            "column": {
+              "start": 5,
+              "end": 20
+            }
+          },
+          {
+            "value": "wiki.fga",
+            "line": {
+              "start": 7,
+              "end": 7
+            },
+            "column": {
+              "start": 5,
+              "end": 13
+            }
+          }
+        ],
+        "line": {
+          "start": 4,
+          "end": 8
+        },
+        "column": {
+          "start": 3,
+          "end": 1
+        }
+      }
     }
 - name: missing schema
   modFile: |


### PR DESCRIPTION
## Description

Changes the return type of the `transformModFileToJSON` to a structure that allows us to return line and column information as part of the data to allow us to improve error reporting without tying us to the underlying yaml parser that we use on each platform.

Currently only has the JS implementation and will follow up with the Go implementation.

## References

Resolves #173

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
