### PR TITLE
chore: remove module from fga.mod definition

### DIFF
--- a/pkg/go/transformer/mod-to-json.go
+++ b/pkg/go/transformer/mod-to-json.go
@@ -22,13 +22,11 @@ type ModFileArrayProperty struct {
 
 type ModFile struct {
 	Schema   ModFileStringProperty `json:"schema"`
-	Module   ModFileStringProperty `json:"module"`
 	Contents ModFileArrayProperty  `json:"contents"`
 }
 
 type YAMLModFile struct {
 	Schema   yaml.Node `yaml:"schema"`
-	Module   yaml.Node `yaml:"module"`
 	Contents yaml.Node `yaml:"contents"`
 }
 
@@ -104,27 +102,6 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 			Value:  yamlModFile.Schema.Value,
 			Line:   yamlModFile.Schema.Line,
 			Column: yamlModFile.Schema.Column,
-		}
-	}
-
-	switch {
-	case yamlModFile.Module.IsZero():
-		errors = multierror.Append(errors, &ModFileValidationError{
-			Msg:    "missing module field",
-			Line:   1,
-			Column: 1,
-		})
-	case yamlModFile.Module.Tag != stringNode:
-		errors = multierror.Append(errors, &ModFileValidationError{
-			Msg:    "unexpected module type, expected string got value " + yamlModFile.Module.Value,
-			Line:   yamlModFile.Module.Line,
-			Column: yamlModFile.Module.Column,
-		})
-	default:
-		modFile.Module = ModFileStringProperty{
-			Value:  yamlModFile.Module.Value,
-			Line:   yamlModFile.Module.Line,
-			Column: yamlModFile.Module.Column,
 		}
 	}
 

--- a/pkg/go/transformer/mod-to-json_test.go
+++ b/pkg/go/transformer/mod-to-json_test.go
@@ -53,7 +53,6 @@ func TestModFileToJSONTransformer(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.NotNil(t, actual.Schema.Value)
-				assert.NotNil(t, actual.Module.Value)
 				assert.NotNil(t, actual.Contents.Value)
 			}
 		})

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -38,10 +38,6 @@ export interface ModFile {
    */
   schema: ModFileProperty<string>
   /**
-   * The module name.
-   */
-  module: ModFileProperty<string>
-  /**
    * The individual files that make up the modular model.
    */
   contents: ModFileProperty<ModFileProperty<string>[]>
@@ -146,24 +142,6 @@ export const transformModFileToJSON = (modFile: string): ModFile => {
     parsedModFile.schema = {
       value: schemaNode.value,
       ...getLineAndColumnFromNode(schemaNode, lineCounter)
-    };
-  }
-
-  const moduleNode = yamlDoc.get("module", true) as Scalar<string>;
-  if (!moduleNode) {
-    errors.push(new FGAModFileValidationSingleError({
-      msg: "missing module field",
-      ...getLineAndColumnFromLinePos()
-    }));
-  } else if (typeof moduleNode.value !== "string") {
-    errors.push(new FGAModFileValidationSingleError({
-      msg: `unexpected module type, expected string got value ${moduleNode.value}`,
-      ...getLineAndColumnFromNode(moduleNode, lineCounter)
-    }));
-  } else {
-    parsedModFile.module = {
-      value: moduleNode.value,
-      ...getLineAndColumnFromNode(moduleNode, lineCounter)
     };
   }
 

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -2,7 +2,6 @@
 - name: valid syntax
   modFile: |
     schema: '1.2'
-    module: acme
     contents:
       - core.fga
       - team1/project.fga
@@ -21,24 +20,13 @@
           "end": 14
         }
       },
-      "module":{
-        "value": "acme",
-        "line": {
-          "start": 2,
-          "end": 2
-        },
-        "column": {
-          "start": 9,
-          "end": 13
-        }
-      },
       "contents": {
         "value": [
           {
             "value": "core.fga",
             "line": {
-              "start": 4,
-              "end": 4
+              "start": 3,
+              "end": 3
             },
             "column": {
               "start": 5,
@@ -48,8 +36,8 @@
           {
             "value": "team1/project.fga",
             "line": {
-              "start": 5,
-              "end": 5
+              "start": 4,
+              "end": 4
             },
             "column": {
               "start": 5,
@@ -59,8 +47,8 @@
           {
             "value": "team1/board.fga",
             "line": {
-              "start": 6,
-              "end": 6
+              "start": 5,
+              "end": 5
             },
             "column": {
               "start": 5,
@@ -70,8 +58,8 @@
           {
             "value": "wiki.fga",
             "line": {
-              "start": 7,
-              "end": 7
+              "start": 6,
+              "end": 6
             },
             "column": {
               "start": 5,
@@ -80,8 +68,8 @@
           }
         ],
         "line": {
-          "start": 4,
-          "end": 8
+          "start": 3,
+          "end": 7
         },
         "column": {
           "start": 3,
@@ -91,7 +79,6 @@
     }
 - name: missing schema
   modFile: |
-    module: acme
     contents:
       - core.fga
   expected_errors:
@@ -105,7 +92,6 @@
 - name: invalid schema type
   modFile: |
     schema: true
-    module: acme
     contents:
       - core.fga
   expected_errors:
@@ -119,7 +105,6 @@
 - name: invalid schema version
   modFile: |
     schema: "1.1"
-    module: acme
     contents:
       - core.fga
   expected_errors:
@@ -130,37 +115,9 @@
       column:
         start: 9
         end: 14
-- name: missing module
-  modFile: |
-    schema: "1.2"
-    contents:
-      - core.fga
-  expected_errors:
-    - msg: missing module field
-      line:
-        start: 1
-        end: 1
-      column:
-        start: 1
-        end: 1
-- name: invalid module type
-  modFile: |
-    schema: "1.2"
-    module: true
-    contents:
-      - core.fga
-  expected_errors:
-    - msg: unexpected module type, expected string got value true
-      line:
-        start: 2
-        end: 2
-      column:
-        start: 9
-        end: 13
 - name: missing contents
   modFile: |
     schema: "1.2"
-    module: acme
   expected_errors:
     - msg: missing contents field
       line:
@@ -172,49 +129,46 @@
 - name: invalid contents type
   modFile: |
     schema: "1.2"
-    module: acme
     contents: true
   expected_errors:
     - msg: unexpected contents type, expected list of strings got value true
       line:
-        start: 3
-        end: 3
+        start: 2
+        end: 2
       column:
         start: 11
         end: 15
 - name: contents is not a list of strings
   modFile: |
     schema: "1.2"
-    module: acme
     contents:
       - true
       - 1
   expected_errors:
     - msg: unexpected contents item type, expected string got value true
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
         start: 5
         end: 9
     - msg: unexpected contents item type, expected string got value 1
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 5
         end: 6
 - name: contents item does not end with `.fga`
   modFile: |
     schema: "1.2"
-    module: acme
     contents:
       - core.txt
   expected_errors:
     - msg: contents items should use fga file extension, got core.txt
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
         start: 5
         end: 13


### PR DESCRIPTION
## Description

We initially added a `module` field to the `fga.mod` file, however after some thinking I'm proposing that we remove this field for the following:

* It doesn't actually do anything and can get erased as we never transfer it over to the transformed model (i.e.  a modular model is reconstructed from the JSON then it will be lost unlike schema version and contents).
* There doesn't seem to be (to me) a reason for it's existence, each module file will contain a module name and in the current iteration there doesn't seem to be any value to having a top-level module name. Whilst one might exist in the future I feel that attempting to design for that now might paint us into a corner as we do not know any future needs right now.

## References



## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
