### PR TITLE
feat: allow passing a custom schema version to modular transform

### DIFF
--- a/pkg/go/transformer/module-to-model.go
+++ b/pkg/go/transformer/module-to-model.go
@@ -57,9 +57,12 @@ func (e *ModuleValidationMultipleError) Error() string {
 }
 
 // TransformModuleFilesToModel transforms the provided modules into a singular authorization model.
-func TransformModuleFilesToModel(modules []ModuleFile) (*pb.AuthorizationModel, error) { //nolint:funlen,gocognit,cyclop
+func TransformModuleFilesToModel( //nolint:funlen,gocognit,cyclop
+	modules []ModuleFile,
+	schemaVersion string,
+) (*pb.AuthorizationModel, error) {
 	model := &pb.AuthorizationModel{
-		SchemaVersion:   "1.2",
+		SchemaVersion:   schemaVersion,
 		TypeDefinitions: []*pb.TypeDefinition{},
 		Conditions:      map[string]*pb.Condition{},
 	}

--- a/pkg/go/transformer/module-to-model_test.go
+++ b/pkg/go/transformer/module-to-model_test.go
@@ -30,7 +30,7 @@ func TestTransformModuleToJSON(t *testing.T) {
 				t.Skip()
 			}
 
-			actual, err := transformer.TransformModuleFilesToModel(testCase.Modules)
+			actual, err := transformer.TransformModuleFilesToModel(testCase.Modules, "1.2")
 			if len(testCase.ExpectedErrors) == 0 {
 				require.NoError(t, err)
 
@@ -83,4 +83,19 @@ func TestTransformModuleToJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	actual, err := transformer.TransformModuleFilesToModel([]transformer.ModuleFile{
+		{
+			Name: "core.fga",
+			Contents: `module core
+  type user`,
+		},
+	}, "1.1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.1", actual.GetSchemaVersion())
 }

--- a/pkg/js/tests/modules/module-to-model.test.ts
+++ b/pkg/js/tests/modules/module-to-model.test.ts
@@ -10,12 +10,12 @@ describe("transformModuleFilesToModel", () => {
 
         testFn(`transformModuleFilesToModel ${testCase.name}`, () => {
             if (!testCase.expected_errors) {
-                expect(transformModuleFilesToModel(testCase.modules, { schemaVersion: "1.2" })).toEqual(
+                expect(transformModuleFilesToModel(testCase.modules, "1.2")).toEqual(
                     JSON.parse(testCase.json)
                 );
             } else {
                 try {
-                    transformModuleFilesToModel(testCase.modules, { schemaVersion: "1.2" });
+                    transformModuleFilesToModel(testCase.modules,  "1.2");
                 } catch (error) {
                     expect(error).toBeInstanceOf(ModuleTransformationError);
                     const exception = error as ModuleTransformationError;
@@ -48,7 +48,7 @@ describe("transformModuleFilesToModel", () => {
             name: "core.fga",
             contents: `module core
   type user`
-        }], { schemaVersion: "1.1" });
+        }], "1.1");
 
         expect(model.schema_version).toEqual("1.1");
     });

--- a/pkg/js/tests/modules/module-to-model.test.ts
+++ b/pkg/js/tests/modules/module-to-model.test.ts
@@ -10,10 +10,12 @@ describe("transformModuleFilesToModel", () => {
 
         testFn(`transformModuleFilesToModel ${testCase.name}`, () => {
             if (!testCase.expected_errors) {
-                expect(transformModuleFilesToModel(testCase.modules)).toEqual(JSON.parse(testCase.json));
+                expect(transformModuleFilesToModel(testCase.modules, { schemaVersion: "1.2" })).toEqual(
+                    JSON.parse(testCase.json)
+                );
             } else {
                 try {
-                    transformModuleFilesToModel(testCase.modules);
+                    transformModuleFilesToModel(testCase.modules, { schemaVersion: "1.2" });
                 } catch (error) {
                     expect(error).toBeInstanceOf(ModuleTransformationError);
                     const exception = error as ModuleTransformationError;
@@ -39,5 +41,15 @@ describe("transformModuleFilesToModel", () => {
                 }
             }
         });
+    });
+
+    it("should allow passing a custom schema version", () => {
+        const model = transformModuleFilesToModel([{
+            name: "core.fga",
+            contents: `module core
+  type user`
+        }], { schemaVersion: "1.1" });
+
+        expect(model.schema_version).toEqual("1.1");
     });
 });

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -16,13 +16,20 @@ export interface ModuleFile {
   contents: string;
 }
 
-export const transformModuleFilesToModel = (files: ModuleFile[]): Omit<AuthorizationModel, "id"> => {
+export interface TransformModuleOptions {
+  schemaVersion: string;
+}
+
+export const transformModuleFilesToModel = (
+  files: ModuleFile[],
+  options: TransformModuleOptions
+): Omit<AuthorizationModel, "id"> => {
   // Build all the individual models
   // Validate them (no conflicting names that aren't extensions?)
   // Copy over any extensions?
   // Stitch them into the main model
   const model: Omit<AuthorizationModel, "id"> = {
-    schema_version: "1.2",
+    schema_version: options.schemaVersion,
     type_definitions: [],
     conditions: {}
   };

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -16,20 +16,12 @@ export interface ModuleFile {
   contents: string;
 }
 
-export interface TransformModuleOptions {
-  schemaVersion: string;
-}
-
 export const transformModuleFilesToModel = (
   files: ModuleFile[],
-  options: TransformModuleOptions
+  schemaVersion: string
 ): Omit<AuthorizationModel, "id"> => {
-  // Build all the individual models
-  // Validate them (no conflicting names that aren't extensions?)
-  // Copy over any extensions?
-  // Stitch them into the main model
   const model: Omit<AuthorizationModel, "id"> = {
-    schema_version: options.schemaVersion,
+    schema_version: schemaVersion,
     type_definitions: [],
     conditions: {}
   };


### PR DESCRIPTION
## Description

Adds support for passing the schema version when transforming a modular model.

Initially I was going to do this in an optional manner, but then realised that realistically anyone who is using this will always pass the schema version anyway so it made sense to move this to required and not have a default version.

Validation is left to the standard validation logic.

## References

Closes #188

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
