### PR TITLE
chore(go): filter out validation errors when constructing go testcases

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -13,13 +13,13 @@ on:
       - 'pkg/go/**'
       - 'OpenFGAParser.g4'
       - 'OpenFGALexer.g4'
-      - 'tests'
+      - 'tests/**'
   pull_request:
     paths:
       - 'pkg/go/**'
       - 'OpenFGAParser.g4'
       - 'OpenFGALexer.g4'
-      - 'tests'
+      - 'tests/**'
 
 permissions:
   contents: read

--- a/.github/workflows/main-js.yaml
+++ b/.github/workflows/main-js.yaml
@@ -19,7 +19,7 @@ on:
       - 'pkg/js/**'
       - 'OpenFGAParser.g4'
       - 'OpenFGALexer.g4'
-      - 'tests'
+      - 'tests/**'
 
 permissions:
   contents: read

--- a/pkg/go/transformer/module-to-model_test.go
+++ b/pkg/go/transformer/module-to-model_test.go
@@ -55,6 +55,8 @@ func TestTransformModuleToJSON(t *testing.T) {
 				if errors.As(err, &verr) {
 					errors := verr.Errors
 
+					require.Equal(t, len(errors), len(testCase.ExpectedErrors), "did not get the expected amount of errors")
+
 					for i := 0; i < len(testCase.ExpectedErrors); i++ {
 						errorDetails := testCase.ExpectedErrors[i]
 						expected := errors[i]

--- a/pkg/go/transformer/testcases_test.go
+++ b/pkg/go/transformer/testcases_test.go
@@ -24,11 +24,16 @@ type startEnd struct {
 	End   int `json:"end,omitempty"   yaml:"end,omitempty"`
 }
 
+type meta struct {
+	ErrorType string `json:"errorType" yaml:"errorType"` //nolint:tagliatelle
+}
+
 type expectedError struct {
-	Msg    string   `json:"msg"    yaml:"msg"`
-	Line   startEnd `json:"line"   yaml:"line"`
-	Column startEnd `json:"column" yaml:"column"`
-	File   string   `json:"file"   yaml:"file"`
+	Msg      string   `json:"msg"      yaml:"msg"`
+	Line     startEnd `json:"line"     yaml:"line"`
+	Column   startEnd `json:"column"   yaml:"column"`
+	File     string   `json:"file"     yaml:"file"`
+	Metadata meta     `json:"metadata" yaml:"metadata"`
 }
 
 func (testCase *invalidDslSyntaxTestCase) GetErrorString() string {
@@ -237,6 +242,17 @@ func loadModuleTestCases() ([]moduleTestCase, error) { //nolint:cyclop
 			if err != nil {
 				return nil, err //nolint:wrapcheck
 			}
+
+			errors := []expectedError{}
+
+			// Ignore any errors that are from validation performed on the constructed model
+			for _, err := range testCase.ExpectedErrors {
+				if err.Metadata.ErrorType == "" {
+					errors = append(errors, err)
+				}
+			}
+
+			testCase.ExpectedErrors = errors
 		}
 
 		moduleDirectory := filepath.Join(testDataPath, testCase.Name, "module")


### PR DESCRIPTION
## Description

The Go package currently doesn't have validation so we want to ignore those specific errors when running the modular transform tests, we can detect these by if they have `metadata.errorType` set so we filter them out when constructing out test case.

Also corrects the `paths` used to include the `**` so that changes under tests will trigger the JS and Go tests to run even if the source files aren't touched

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
