### PR TITLE
chore: correctly handle syntax errors during parsing of the dsl

### DIFF
--- a/pkg/go/transformer/module-to-model.go
+++ b/pkg/go/transformer/module-to-model.go
@@ -81,7 +81,7 @@ func TransformModuleFilesToModel( //nolint:funlen,gocognit,cyclop
 
 		mdl, typeDefExtensions, err := TransformModularDSLToProto(module.Contents)
 		if err != nil {
-			var syntaxError *OpenFgaDslSyntaxMultipleError
+			var syntaxError *multierror.Error
 			if errors.As(err, &syntaxError) {
 				transformErrors = multierror.Append(transformErrors, syntaxError.Errors...)
 			}

--- a/pkg/go/transformer/module-to-model_test.go
+++ b/pkg/go/transformer/module-to-model_test.go
@@ -2,6 +2,7 @@ package transformer_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	pb "github.com/openfga/api/proto/openfga/v1"
@@ -59,27 +60,22 @@ func TestTransformModuleToJSON(t *testing.T) {
 
 					for i := 0; i < len(testCase.ExpectedErrors); i++ {
 						errorDetails := testCase.ExpectedErrors[i]
-						expected := errors[i]
-						actual := &transformer.ModuleTransformationSingleError{
-							Line: struct {
-								Start int
-								End   int
-							}{
-								Start: errorDetails.Line.Start,
-								End:   errorDetails.Line.End,
-							},
-							Column: struct {
-								Start int
-								End   int
-							}{
-								Start: errorDetails.Column.Start,
-								End:   errorDetails.Column.End,
-							},
-							Msg:  errorDetails.Msg,
-							File: errorDetails.File,
+						actual := errors[i]
+
+						errorType := "transformation"
+						if errorDetails.Type != "" {
+							errorType = errorDetails.Type
 						}
 
-						assert.Equal(t, expected, actual)
+						assert.Equal(t,
+							fmt.Sprintf("%s error at line=%d, column=%d: %s",
+								errorType,
+								errorDetails.Line.Start,
+								errorDetails.Column.Start,
+								errorDetails.Msg,
+							),
+							actual.Error(),
+						)
 					}
 				}
 			}

--- a/pkg/go/transformer/testcases_test.go
+++ b/pkg/go/transformer/testcases_test.go
@@ -34,6 +34,7 @@ type expectedError struct {
 	Column   startEnd `json:"column"   yaml:"column"`
 	File     string   `json:"file"     yaml:"file"`
 	Metadata meta     `json:"metadata" yaml:"metadata"`
+	Type     string   `json:"type"     yaml:"type"`
 }
 
 func (testCase *invalidDslSyntaxTestCase) GetErrorString() string {
@@ -194,10 +195,16 @@ func (testCase *moduleTestCase) GetErrorString() string {
 	}
 
 	errorsString := []string{}
+
 	for _, err := range testCase.ExpectedErrors {
+		errorType := "transformation"
+		if err.Type != "" {
+			errorType = err.Type
+		}
+
 		errorsString = append(
 			errorsString,
-			fmt.Sprintf("transformation error at line=%d, column=%d: %s", err.Line.Start, err.Column.Start, err.Msg),
+			fmt.Sprintf("%s error at line=%d, column=%d: %s", errorType, err.Line.Start, err.Column.Start, err.Msg),
 		)
 	}
 

--- a/pkg/js/tests/modules/module-to-model.test.ts
+++ b/pkg/js/tests/modules/module-to-model.test.ts
@@ -1,4 +1,9 @@
-import { ModelValidationSingleError, ModuleTransformationError, ModuleTransformationSingleError } from "../../errors";
+import {
+    DSLSyntaxSingleError,
+    ModelValidationSingleError,
+    ModuleTransformationError,
+    ModuleTransformationSingleError
+} from "../../errors";
 import { transformModuleFilesToModel } from "../../transformer/modules/modules-to-model";
 import { loadModuleTestCases } from "../_testcases";
 
@@ -23,15 +28,17 @@ describe("transformModuleFilesToModel", () => {
                     const errorsCount = testCase.expected_errors.length;
                     expect(exception.message).toEqual(
                         `${errorsCount} error${errorsCount === 1 ? "" : "s"} occurred:\n\t* ${testCase.expected_errors
-                        .map((err: ModelValidationSingleError|ModuleTransformationSingleError) => {
+                        .map((err: ModelValidationSingleError|ModuleTransformationSingleError|DSLSyntaxSingleError) => {
                             let errorType = "transformation-error";
                             if ((err as ModelValidationSingleError).metadata?.errorType) {
                                 errorType = (err as ModelValidationSingleError).metadata!.errorType;
+                            } else if ((err as DSLSyntaxSingleError).type) {
+                                errorType = err.type;
                             }
 
                             let msg = `${errorType} error`;
-                            if (err?.line && !err.metadata) {
-                                msg += ` at line=${err.line.start}, column=${err.column?.start}`;
+                            if (!err.metadata || err.type) {
+                                msg += ` at line=${err.line?.start}, column=${err.column?.start}`;
                             }
                             msg += `: ${err.msg}`;
                             return msg;

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -94,7 +94,10 @@ export const transformModuleFilesToModel = (
       }
     } catch (error) {
       if (error instanceof DSLSyntaxError) {
-        errors.push(...error.errors);
+        for (const e of error.errors) {
+          e.file = name;
+          errors.push(e);
+        }
       } else if (error instanceof Error) {
         errors.push(error as BaseError);
       }

--- a/tests/data/transformer-module/01-module-with-errors/expected_errors.json
+++ b/tests/data/transformer-module/01-module-with-errors/expected_errors.json
@@ -24,6 +24,19 @@
     }
   },
   {
+    "msg": "no viable alternative at input '\\n  define'",
+    "file": "syntax-error.fga",
+    "line": {
+      "start": 4,
+      "end": 4
+    },
+    "column": {
+      "start": 2,
+      "end": 8
+    },
+    "type": "syntax"
+  },
+  {
     "msg": "extended type noexist does not exist",
     "file": "org.fga",
     "line": {

--- a/tests/data/transformer-module/01-module-with-errors/module/syntax-error.fga
+++ b/tests/data/transformer-module/01-module-with-errors/module/syntax-error.fga
@@ -1,0 +1,4 @@
+module syntax-error
+
+type another
+  define foo: [user]


### PR DESCRIPTION
## Description

Adds a test for a DSL file with a syntax error and then ensure that we correctly return this as part of the overall modular model transform

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
