### PR TITLE
refactor(js): move exceptioncollector to be a class

### DIFF
--- a/pkg/js/util/exceptions.ts
+++ b/pkg/js/util/exceptions.ts
@@ -386,92 +386,130 @@ interface Meta {
   module?: string;
 }
 
-export const exceptionCollector = (errors: ModelValidationSingleError[], lines?: string[]) => {
-  return {
-    raiseInvalidName(symbol: string, clause: string, typeName?: string, lineIndex?: number, metadata?: Meta) {
-      createInvalidName(
-        { errors, lines, lineIndex, symbol, file: metadata?.file, module: metadata?.module },
-        clause,
-        typeName,
-      );
-    },
-    raiseReservedTypeName(symbol: string, lineIndex?: number, metadata?: Meta) {
-      createReservedTypeNameError({ errors, lines, lineIndex, symbol, file: metadata?.file, module: metadata?.module });
-    },
-    raiseReservedRelationName(symbol: string, lineIndex?: number, metadata?: Meta) {
-      createReservedRelationNameError({
-        errors,
-        lines,
+export class ExceptionCollector {
+  constructor(
+    private errors: ModelValidationSingleError[],
+    private lines?: string[],
+  ) {}
+
+  raiseInvalidName(symbol: string, clause: string, typeName?: string, lineIndex?: number, metadata?: Meta) {
+    createInvalidName(
+      { errors: this.errors, lines: this.lines, lineIndex, symbol, file: metadata?.file, module: metadata?.module },
+      clause,
+      typeName,
+    );
+  }
+
+  raiseReservedTypeName(symbol: string, lineIndex?: number, metadata?: Meta) {
+    createReservedTypeNameError({
+      errors: this.errors,
+      lines: this.lines,
+      lineIndex,
+      symbol,
+      file: metadata?.file,
+      module: metadata?.module,
+    });
+  }
+
+  raiseReservedRelationName(symbol: string, lineIndex?: number, metadata?: Meta) {
+    createReservedRelationNameError({
+      errors: this.errors,
+      lines: this.lines,
+      lineIndex,
+      symbol,
+      file: metadata?.file,
+      module: metadata?.module,
+    });
+  }
+
+  raiseTupleUsersetRequiresDirect(symbol: string, lineIndex?: number) {
+    createTupleUsersetRequireDirectError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseDuplicateTypeName(symbol: string, lineIndex?: number) {
+    createDuplicateTypeNameError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseDuplicateTypeRestriction(symbol: string, relationName: string, lineIndex?: number) {
+    createDuplicateTypeRestrictionError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, relationName);
+  }
+
+  raiseDuplicateType(symbol: string, relationName: string, lineIndex?: number) {
+    createDuplicateRelationError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, relationName);
+  }
+
+  raiseDuplicateRelationshipDefinition(symbol: string, lineIndex?: number) {
+    createDuplicateRelationshipDefinitionError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseNoEntryPointLoop(symbol: string, typeName: string, lineIndex?: number) {
+    createNoEntryPointLoopError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, typeName);
+  }
+
+  raiseNoEntryPoint(symbol: string, typeName: string, lineIndex?: number) {
+    createNoEntryPointError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, typeName);
+  }
+
+  raiseInvalidTypeRelation(symbol: string, typeName: string, relationName: string, lineIndex?: number) {
+    createInvalidTypeRelationError(
+      {
+        errors: this.errors,
+        lines: this.lines,
         lineIndex,
         symbol,
-        file: metadata?.file,
-        module: metadata?.module,
-      });
-    },
-    raiseTupleUsersetRequiresDirect(symbol: string, lineIndex?: number) {
-      createTupleUsersetRequireDirectError({ errors, lines, lineIndex, symbol });
-    },
-    raiseDuplicateTypeName(symbol: string, lineIndex?: number) {
-      createDuplicateTypeNameError({ errors, lines, lineIndex, symbol });
-    },
-    raiseDuplicateTypeRestriction(symbol: string, relationName: string, lineIndex?: number) {
-      createDuplicateTypeRestrictionError({ errors, lines, lineIndex, symbol }, relationName);
-    },
-    raiseDuplicateType(symbol: string, relationName: string, lineIndex?: number) {
-      createDuplicateRelationError({ errors, lines, lineIndex, symbol }, relationName);
-    },
-    raiseDuplicateRelationshipDefinition(symbol: string, lineIndex?: number) {
-      createDuplicateRelationshipDefinitionError({ errors, lines, lineIndex, symbol });
-    },
-    raiseNoEntryPointLoop(symbol: string, typeName: string, lineIndex?: number) {
-      createNoEntryPointLoopError({ errors, lines, lineIndex, symbol }, typeName);
-    },
-    raiseNoEntryPoint(symbol: string, typeName: string, lineIndex?: number) {
-      createNoEntryPointError({ errors, lines, lineIndex, symbol }, typeName);
-    },
-    raiseInvalidTypeRelation(symbol: string, typeName: string, relationName: string, lineIndex?: number) {
-      createInvalidTypeRelationError({ errors, lines, lineIndex, symbol }, typeName, relationName);
-    },
-    raiseInvalidType(symbol: string, typeName: string, lineIndex?: number) {
-      createInvalidTypeError({ errors, lines, lineIndex, symbol }, typeName);
-    },
-    raiseAssignableRelationMustHaveTypes(symbol: string, lineIndex?: number) {
-      createAssignableRelationMustHaveTypesError({ errors, lines, lineIndex, symbol });
-    },
-    raiseAssignableTypeWildcardRelation(symbol: string, lineIndex?: number) {
-      createAssignableTypeWildcardRelationError({ errors, lines, lineIndex, symbol });
-    },
-    raiseInvalidRelationError(symbol: string, validRelations: string[], lineIndex?: number) {
-      createInvalidRelationError({ errors, lines, lineIndex, symbol }, validRelations);
-    },
-    raiseInvalidSchemaVersion(symbol: string, lineIndex?: number) {
-      createInvalidSchemaVersionError({ errors, lines, lineIndex, symbol });
-    },
-    raiseSchemaVersionRequired(symbol: string, lineIndex?: number) {
-      createSchemaVersionRequiredError({ errors, lines, lineIndex, symbol });
-    },
-    raiseMaximumOneDirectRelationship(symbol: string, lineIndex?: number) {
-      createMaximumOneDirectRelationship({ errors, lines, lineIndex, symbol });
-    },
-    raiseInvalidConditionNameInParameter(
-      symbol: string,
-      typeName: string,
-      relationName: string,
-      conditionName: string,
-      lineIndex?: number,
-    ) {
-      createInvalidConditionNameInParameterError(
-        { errors, lines, lineIndex, symbol },
-        typeName,
-        relationName,
-        conditionName,
-      );
-    },
-    raiseUnusedCondition(symbol: string, lineIndex?: number) {
-      createUnusedConditionError({ errors, lines, lineIndex, symbol });
-    },
-  };
-};
+      },
+      typeName,
+      relationName,
+    );
+  }
+
+  raiseInvalidType(symbol: string, typeName: string, lineIndex?: number) {
+    createInvalidTypeError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, typeName);
+  }
+
+  raiseAssignableRelationMustHaveTypes(symbol: string, lineIndex?: number) {
+    createAssignableRelationMustHaveTypesError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseAssignableTypeWildcardRelation(symbol: string, lineIndex?: number) {
+    createAssignableTypeWildcardRelationError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseInvalidRelationError(symbol: string, validRelations: string[], lineIndex?: number) {
+    createInvalidRelationError({ errors: this.errors, lines: this.lines, lineIndex, symbol }, validRelations);
+  }
+
+  raiseInvalidSchemaVersion(symbol: string, lineIndex?: number) {
+    createInvalidSchemaVersionError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseSchemaVersionRequired(symbol: string, lineIndex?: number) {
+    createSchemaVersionRequiredError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseMaximumOneDirectRelationship(symbol: string, lineIndex?: number) {
+    createMaximumOneDirectRelationship({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+
+  raiseInvalidConditionNameInParameter(
+    symbol: string,
+    typeName: string,
+    relationName: string,
+    conditionName: string,
+    lineIndex?: number,
+  ) {
+    createInvalidConditionNameInParameterError(
+      { errors: this.errors, lines: this.lines, lineIndex, symbol },
+      typeName,
+      relationName,
+      conditionName,
+    );
+  }
+
+  raiseUnusedCondition(symbol: string, lineIndex?: number) {
+    createUnusedConditionError({ errors: this.errors, lines: this.lines, lineIndex, symbol });
+  }
+}
 
 interface TransformationErrorProps {
   message: string;

--- a/pkg/js/validator/validate-dsl.ts
+++ b/pkg/js/validator/validate-dsl.ts
@@ -2,7 +2,7 @@ import type { AuthorizationModel, RelationReference, RelationMetadata, TypeDefin
 import { Keyword, ReservedKeywords } from "./keywords";
 import { parseDSL } from "../transformer";
 import { ConfigurationError, DSLSyntaxError, ModelValidationError, ModelValidationSingleError } from "../errors";
-import { exceptionCollector } from "../util/exceptions";
+import { ExceptionCollector } from "../util/exceptions";
 
 // eslint-disable-next-line no-useless-escape
 const defaultTypeRule = "^[^:#@\\s]{1,254}$";
@@ -360,8 +360,7 @@ const getSchemaLineNumber = (schema: string, lines?: string[]) => {
 };
 
 function checkForDuplicatesTypeNamesInRelation(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   relationDef: RelationMetadata,
   relationName: string,
   lines?: string[],
@@ -381,8 +380,7 @@ function checkForDuplicatesTypeNamesInRelation(
 
 // ensure all the referenced relations are defined
 function checkForDuplicatesInRelation(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   typeDef: TypeDefinition,
   relationName: string,
   lines?: string[],
@@ -427,8 +425,7 @@ function checkForDuplicatesInRelation(
 
 // helper function to ensure all childDefs are defined
 function childDefDefined(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   typeMap: Record<string, TypeDefinition>,
   type: string,
   relation: string,
@@ -569,8 +566,7 @@ function childDefDefined(
 
 // ensure all the referenced relations are defined
 function relationDefined(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   typeMap: Record<string, TypeDefinition>,
   type: string,
   relation: string,
@@ -601,8 +597,7 @@ function relationDefined(
 }
 
 function modelValidation(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   errors: ModelValidationSingleError[],
   authorizationModel: AuthorizationModel,
   //relationsPerType: Record<string, TransformedType>
@@ -709,8 +704,7 @@ function modelValidation(
 }
 
 function populateRelations(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  collector: any,
+  collector: ExceptionCollector,
   authorizationModel: AuthorizationModel,
   typeRegex: ValidationRegex,
   relationRegex: ValidationRegex,
@@ -778,7 +772,7 @@ export function validateJSON(
 ): void {
   const lines = dslString?.split("\n");
   const errors: ModelValidationSingleError[] = [];
-  const collector = exceptionCollector(errors, lines);
+  const collector = new ExceptionCollector(errors, lines);
   const typeValidation = options.typeValidation || defaultTypeRule;
   const relationValidation = options.relationValidation || defaultRelationRule;
   const defaultRegex = new RegExp("[a-zA-Z]*");


### PR DESCRIPTION
## Description

This PR proposed moving the existing `exceptionCollector` function to be a class, we're already kind of mimicking this by returning an object with the functions attached but by moving to a class it means we can more easily type the `collector` we pass around and when refactoring we're able to get typing.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
