### PR TITLE
fix(js,java): correct error thrown when using a wildcard as a from re…

### DIFF
--- a/pkg/java/src/main/java/dev/openfga/language/validation/DslValidator.java
+++ b/pkg/java/src/main/java/dev/openfga/language/validation/DslValidator.java
@@ -342,12 +342,8 @@ public class DslValidator {
                                 var type = DestructuredTupleToUserset.from(item);
                                 var decodedType = type.getDecodedType();
                                 var decodedRelation = type.getDecodedRelation();
-                                var isWilcard = type.isWildcard();
-                                if (isWilcard) {
-                                    var typeIndex = dsl.getTypeLineNumber(typeName);
-                                    var lineIndex = dsl.getRelationLineNumber(relationName, typeIndex);
-                                    errors.raiseAssignableTypeWildcardRelation(lineIndex, item);
-                                } else if (decodedRelation != null) {
+                                var isWildcard = type.isWildcard();
+                                if (isWildcard || decodedRelation != null) {
                                     var typeIndex = dsl.getTypeLineNumber(typeName);
                                     var lineIndex = dsl.getRelationLineNumber(relationName, typeIndex);
                                     errors.raiseTupleUsersetRequiresDirect(lineIndex, childDef.getFrom());

--- a/pkg/js/validator/validate-dsl.ts
+++ b/pkg/js/validator/validate-dsl.ts
@@ -520,12 +520,8 @@ function childDefDefined(
             const childRelationNotValid = [];
             for (const item of fromTypes) {
               const { decodedType, decodedRelation, isWildcard } = destructTupleToUserset(item);
-              if (isWildcard) {
-                // we cannot have both wild carded and relation at the same time
-                const typeIndex = getTypeLineNumber(type, lines);
-                const lineIndex = getRelationLineNumber(relation, lines, typeIndex);
-                collector.raiseAssignableTypeWildcardRelation(item, lineIndex);
-              } else if (decodedRelation) {
+              if (isWildcard || decodedRelation) {
+                // we cannot have both wildcard or decoded relation and relation at the same time
                 const typeIndex = getTypeLineNumber(type, lines);
                 const lineIndex = getRelationLineNumber(relation, lines, typeIndex);
                 collector.raiseTupleUsersetRequiresDirect(childDef.from, lineIndex);

--- a/tests/data/dsl-semantic-validation-cases.yaml
+++ b/tests/data/dsl-semantic-validation-cases.yaml
@@ -741,16 +741,16 @@
         define parent: [document, document:*]
         define viewer: [user] or viewer from parent
   expected_errors:
-    - msg: 'type restriction `document:*` cannot contain both wildcard and relation'
+    - msg: '`parent` relation used inside from allows only direct relation.'
       line:
         start: 7
         end: 7
       column:
-        start: 1
-        end: 11
+        start: 42
+        end: 48
       metadata:
-        symbol: "document:*"
-        errorType: type-wildcard-relation
+        symbol: "parent"
+        errorType: tupleuset-not-direct
 - name: duplicate types
   dsl: |
     model


### PR DESCRIPTION
## Description

Fixes the `self reference with wildcard` test to correctly report a `tupleuset-not-direct` error and fix the line/column numbers

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
