### PR TITLE
Run semantic validation test cases against transformModuleFilesToModel 

### DIFF
--- a/pkg/js/tests/modules/module-to-model.test.ts
+++ b/pkg/js/tests/modules/module-to-model.test.ts
@@ -123,7 +123,3 @@ describe("transformModuleFilesToModel - module test cases", () => {
     expect(model.schema_version).toEqual("1.1");
   });
 });
-
-describe("transformModuleFilesToModel - semantic validation test cases", () => {
-  
-});

--- a/pkg/js/tests/modules/module-to-model.test.ts
+++ b/pkg/js/tests/modules/module-to-model.test.ts
@@ -6,11 +6,11 @@ import {
   ModuleTransformationSingleError,
 } from "../../errors";
 import { transformModuleFilesToModel } from "../../transformer/modules/modules-to-model";
-import { loadModuleTestCases } from "../_testcases";
+import { loadDSLValidationErrorTestCases, loadModuleTestCases } from "../_testcases";
 
-describe("transformModuleFilesToModel", () => {
-  const testCases = loadModuleTestCases();
-  testCases.forEach((testCase) => {
+describe("transformModuleFilesToModel - module test cases", () => {
+  const moduleTestCases = loadModuleTestCases();
+  moduleTestCases.forEach((testCase) => {
     const testFn = testCase.skip ? it.skip : it;
 
     testFn(`transformModuleFilesToModel ${testCase.name}`, () => {
@@ -54,6 +54,60 @@ describe("transformModuleFilesToModel", () => {
     });
   });
 
+  const semanticValidationTestCases = loadDSLValidationErrorTestCases();
+  semanticValidationTestCases.forEach((testCase) => {
+    let testFn = testCase.skip ? it.skip : it;
+
+    // Skip any test case already using module as it won't be valid
+    if (testCase.dsl.trim().startsWith("module")) {
+      testFn = it.skip;
+    }
+
+    // Skip schema validation errors
+    if (testCase.dsl.includes("0.9")) {
+      testFn = it.skip;
+    }
+
+    testFn(`transformModuleFilesToModel ${testCase.name}`, () => {
+      try {
+        const dsl = testCase.dsl.replace(/model\n {2}schema 1\.1/, "module test\n");
+        transformModuleFilesToModel([{ name: "test.fga", contents: dsl }], "1.2");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleTransformationError);
+        const exception = error as ModuleTransformationError;
+
+        const errorsCount = testCase.expected_errors.length;
+        expect(exception.message).toEqual(
+          `${errorsCount} error${errorsCount === 1 ? "" : "s"} occurred:\n\t* ${testCase.expected_errors
+            .map((err: ModelValidationSingleError | ModuleTransformationSingleError | DSLSyntaxSingleError) => {
+              let errorType = "transformation-error";
+              if ((err as ModelValidationSingleError).metadata?.errorType) {
+                errorType = (err as ModelValidationSingleError).metadata!.errorType;
+              } else if ((err as DSLSyntaxSingleError).type) {
+                errorType = err.type;
+              }
+
+              let msg = `${errorType} error`;
+              if (!err.metadata || err.type) {
+                msg += ` at line=${err.line?.start}, column=${err.column?.start}`;
+              }
+              msg += `: ${err.msg}`;
+              return msg;
+            })
+            .join("\n\t* ")}\n\n`,
+        );
+
+        for (let index = 0; index < errorsCount; index++) {
+          const expected = testCase.expected_errors[index];
+          expected.metadata!.module = "test";
+          // We're asserting an error type against an JSON object here, it works but isn't type correct
+          // @ts-expect-error
+          expect(exception.errors[index]).toMatchObject(expected);
+        }
+      }
+    });
+  });
+
   it("should allow passing a custom schema version", () => {
     const model = transformModuleFilesToModel(
       [
@@ -68,4 +122,8 @@ describe("transformModuleFilesToModel", () => {
 
     expect(model.schema_version).toEqual("1.1");
   });
+});
+
+describe("transformModuleFilesToModel - semantic validation test cases", () => {
+  
 });

--- a/tests/data/transformer-module/01-module-with-errors/expected_errors.json
+++ b/tests/data/transformer-module/01-module-with-errors/expected_errors.json
@@ -1,22 +1,10 @@
 [
   {
-    "msg": "duplicate type definition user",
-    "file": "org.fga",
-    "line": {
-      "start": 2,
-      "end": 2
-    },
-    "column": {
-      "start": 5,
-      "end": 9
-    }
-  },
-  {
     "msg": "duplicate condition a_check",
     "file": "org.fga",
     "line": {
-      "start": 14,
-      "end": 14
+      "start": 12,
+      "end": 12
     },
     "column": {
       "start": 10,
@@ -40,8 +28,8 @@
     "msg": "extended type noexist does not exist",
     "file": "org.fga",
     "line": {
-      "start": 8,
-      "end": 8
+      "start": 6,
+      "end": 6
     },
     "column": {
       "start": 12,
@@ -52,8 +40,8 @@
     "msg": "relation foo already exists on type other",
     "file": "org.fga",
     "line": {
-      "start": 12,
-      "end": 12
+      "start": 10,
+      "end": 10
     },
     "column": {
       "start": 11,

--- a/tests/data/transformer-module/01-module-with-errors/module/org.fga
+++ b/tests/data/transformer-module/01-module-with-errors/module/org.fga
@@ -1,7 +1,5 @@
 module org
 
-type user
-
 type org
   relations
     define member: [user with a_check]


### PR DESCRIPTION
## Description

Introduces more tests for `transformModuleFilesToModel` by running the existing semantic validation suite against it by slightly editing the DSL and using as a single file module.

* 62c656dbaad0798de64947331ac4f8e0f20a4c6a - Sets up the testing
* 9dd3d63d512bf56a976fbc3b0ff7572c9501a2eb - Copies the fix from #219
* 7c1e36ce2c9cf92ea69fe33aeeb96fc30e8a5c0f - Handles the missed duplicates errors as this was already being handled by the code in `transformModuleFilesToModel`, I've removed this from the transform code and instead we're mapping the errors from the validate function as I think realistically we want to try and perform as little validation in transform as possible.

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
