### PR TITLE
ci: run java when test files change, correct merge_group usage

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -9,11 +9,7 @@ on:
     tags:
       - 'v*'
   merge_group:
-    paths:
-      - 'pkg/go/**'
-      - 'OpenFGAParser.g4'
-      - 'OpenFGALexer.g4'
-      - 'tests/**'
+    types: [checks_requested]
   pull_request:
     paths:
       - 'pkg/go/**'

--- a/.github/workflows/main-java.yml
+++ b/.github/workflows/main-java.yml
@@ -8,17 +8,13 @@ on:
     tags:
       - 'v*'
   merge_group:
-    paths:
-      - 'pkg/java/**'
-      - 'OpenFGAParser.g4'
-      - 'OpenFGALexer.g4'
-      - 'tests'
+    types: [checks_requested]
   pull_request:
     paths:
       - 'pkg/java/**'
       - 'OpenFGAParser.g4'
       - 'OpenFGALexer.g4'
-      - 'tests'
+      - tests/**'
 
 permissions:
   contents: read

--- a/.github/workflows/main-js.yaml
+++ b/.github/workflows/main-js.yaml
@@ -9,11 +9,7 @@ on:
     tags:
       - 'v*'
   merge_group:
-    paths:
-      - 'pkg/js/**'
-      - 'OpenFGAParser.g4'
-      - 'OpenFGALexer.g4'
-      - 'tests'
+    types: [checks_requested]
   pull_request:
     paths:
       - 'pkg/js/**'


### PR DESCRIPTION
## Description

Corrects the `Build and Test (Java)` workflow to use the glob syntax to ensure any file under `tests` causes tests to run. Also corrects the `merge_group` usage to match the [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group), it doesn't support paths, only an activity type.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
