### PR TITLE
Make line and column numbers zero based

### DIFF
--- a/pkg/go/transformer/dsltojson.go
+++ b/pkg/go/transformer/dsltojson.go
@@ -463,7 +463,8 @@ func newOpenFgaDslErrorListener() *OpenFgaDslErrorListener {
 func (c *OpenFgaDslErrorListener) SyntaxError(
 	_ antlr.Recognizer,
 	offendingSymbol interface{},
-	line, column int,
+	line, // line is one based, i.e. the first line will be 1
+	column int, // column is one based, i.e. the first column will be 0
 	msg string,
 	_ antlr.RecognitionException,
 ) {

--- a/pkg/go/transformer/dsltojson.go
+++ b/pkg/go/transformer/dsltojson.go
@@ -464,7 +464,7 @@ func (c *OpenFgaDslErrorListener) SyntaxError(
 	_ antlr.Recognizer,
 	offendingSymbol interface{},
 	line, // line is one based, i.e. the first line will be 1
-	column int, // column is one based, i.e. the first column will be 0
+	column int, // column is zero based, i.e. the first column will be 0
 	msg string,
 	_ antlr.RecognitionException,
 ) {

--- a/pkg/go/transformer/dsltojson.go
+++ b/pkg/go/transformer/dsltojson.go
@@ -481,7 +481,7 @@ func (c *OpenFgaDslErrorListener) SyntaxError(
 	}
 
 	c.Errors = multierror.Append(c.Errors, &OpenFgaDslSyntaxError{
-		line:     line,
+		line:     line - 1,
 		column:   column,
 		msg:      msg,
 		metadata: metadata,

--- a/pkg/go/transformer/mod-to-json.go
+++ b/pkg/go/transformer/mod-to-json.go
@@ -82,26 +82,26 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Schema.IsZero():
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "missing schema field",
-			Line:   1,
-			Column: 1,
+			Line:   0,
+			Column: 0,
 		})
 	case yamlModFile.Schema.Tag != stringNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "unexpected schema type, expected string got value " + yamlModFile.Schema.Value,
-			Line:   yamlModFile.Schema.Line,
-			Column: yamlModFile.Schema.Column,
+			Line:   yamlModFile.Schema.Line - 1,
+			Column: yamlModFile.Schema.Column - 1,
 		})
 	case yamlModFile.Schema.Value != "1.2":
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "unsupported schema version, fga.mod only supported in version `1.2`",
-			Line:   yamlModFile.Schema.Line,
-			Column: yamlModFile.Schema.Column,
+			Line:   yamlModFile.Schema.Line - 1,
+			Column: yamlModFile.Schema.Column - 1,
 		})
 	default:
 		modFile.Schema = ModFileStringProperty{
 			Value:  yamlModFile.Schema.Value,
-			Line:   yamlModFile.Schema.Line,
-			Column: yamlModFile.Schema.Column,
+			Line:   yamlModFile.Schema.Line - 1,
+			Column: yamlModFile.Schema.Column - 1,
 		}
 	}
 
@@ -109,14 +109,14 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 	case yamlModFile.Contents.IsZero():
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "missing contents field",
-			Line:   1,
-			Column: 1,
+			Line:   0,
+			Column: 0,
 		})
 	case yamlModFile.Contents.Tag != seqNode:
 		errors = multierror.Append(errors, &ModFileValidationError{
 			Msg:    "unexpected contents type, expected list of strings got value " + yamlModFile.Contents.Value,
-			Line:   yamlModFile.Contents.Line,
-			Column: yamlModFile.Contents.Column,
+			Line:   yamlModFile.Contents.Line - 1,
+			Column: yamlModFile.Contents.Column - 1,
 		})
 	default:
 		contents := []ModFileStringProperty{}
@@ -125,28 +125,28 @@ func TransformModFile(data string) (*ModFile, error) { //nolint:cyclop
 			if file.Tag != stringNode {
 				errors = multierror.Append(errors, &ModFileValidationError{
 					Msg:    "unexpected contents item type, expected string got value " + file.Value,
-					Line:   file.Line,
-					Column: file.Column,
+					Line:   file.Line - 1,
+					Column: file.Column - 1,
 				})
 			} else if !strings.HasSuffix(file.Value, ".fga") {
 				errors = multierror.Append(errors, &ModFileValidationError{
 					Msg:    "contents items should use fga file extension, got " + file.Value,
-					Line:   file.Line,
-					Column: file.Column,
+					Line:   file.Line - 1,
+					Column: file.Column - 1,
 				})
 			}
 
 			contents = append(contents, ModFileStringProperty{
 				Value:  file.Value,
-				Line:   file.Line,
-				Column: file.Column,
+				Line:   file.Line - 1,
+				Column: file.Column - 1,
 			})
 		}
 
 		modFile.Contents = ModFileArrayProperty{
 			Value:  contents,
-			Line:   yamlModFile.Contents.Line,
-			Column: yamlModFile.Contents.Column,
+			Line:   yamlModFile.Contents.Line - 1,
+			Column: yamlModFile.Contents.Column - 1,
 		}
 	}
 

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -48,15 +48,15 @@ func ConstructLineAndColumnData(lines []string, lineIndex int, symbol string) (S
 
 	rawLine := lines[lineIndex]
 
-	wordIdx := strings.Index(rawLine, symbol) + 1
+	wordIdx := strings.Index(rawLine, symbol)
 
-	if wordIdx == 0 {
-		wordIdx = 1
+	if wordIdx == -1 {
+		wordIdx = 0
 	}
 
 	return StartEnd{
-			Start: lineIndex + 1,
-			End:   lineIndex + 1,
+			Start: lineIndex,
+			End:   lineIndex,
 		},
 		StartEnd{
 			Start: wordIdx,

--- a/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
+++ b/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
@@ -23,6 +23,8 @@ public class OpenFgaDslErrorListener implements ANTLRErrorListener {
     }
 
     @Override
+    // line is one based, i.e. the first line will be 1
+    // column is one based, i.e. the first column will 0
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int column, String message, RecognitionException e) {
         Metadata metadata = null;
         var columnOffset = 0;

--- a/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
+++ b/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
@@ -24,7 +24,7 @@ public class OpenFgaDslErrorListener implements ANTLRErrorListener {
 
     @Override
     // line is one based, i.e. the first line will be 1
-    // column is one based, i.e. the first column will 0
+    // column is zero based, i.e. the first column will 0
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int column, String message, RecognitionException e) {
         Metadata metadata = null;
         var columnOffset = 0;

--- a/pkg/java/src/main/java/dev/openfga/language/validation/ValidationErrorsBuilder.java
+++ b/pkg/java/src/main/java/dev/openfga/language/validation/ValidationErrorsBuilder.java
@@ -24,17 +24,17 @@ class ValidationErrorsBuilder {
 
         var rawLine = lines[lineIndex];
         var regex = Pattern.compile("\\b" + symbol + "\\b");
-        var wordIdx = 1;
+        var wordIdx = 0;
         var matcher = regex.matcher(rawLine);
         if (matcher.find()) {
-            wordIdx = matcher.start() + 1;
+            wordIdx = matcher.start();
         }
 
         if (wordResolver != null) {
             wordIdx = wordResolver.resolve(wordIdx, rawLine, symbol);
         }
 
-        var line = new StartEnd(lineIndex + 1, lineIndex + 1);
+        var line = new StartEnd(lineIndex, lineIndex);
         var column = new StartEnd(wordIdx, wordIdx + symbol.length());
         return new ErrorProperties(line, column, message);
     }
@@ -139,8 +139,8 @@ class ValidationErrorsBuilder {
     public void raiseTupleUsersetRequiresDirect(int lineIndex, String symbol) {
         var message = "`" + symbol + "` relation used inside from allows only direct relation.";
         var errorProperties = buildErrorProperties(message, lineIndex, symbol, (wordIndex, rawLine, value) -> {
-            var clauseStartsAt = rawLine.indexOf("from") + "from".length() + 1;
-            wordIndex = clauseStartsAt + rawLine.substring(clauseStartsAt).indexOf(value) + 1;
+            var clauseStartsAt = rawLine.indexOf("from") + "from".length() ;
+            wordIndex = clauseStartsAt + rawLine.substring(clauseStartsAt).indexOf(value);
             return wordIndex;
         });
         var metadata = new ValidationMetadata(symbol, ValidationError.TuplesetNotDirect);

--- a/pkg/js/errors.ts
+++ b/pkg/js/errors.ts
@@ -48,7 +48,8 @@ export interface ErrorMetadata {
 }
 
 /**
- * Abstract base class for syntax and validation exceptions
+ * Abstract base class for syntax and validation exceptions.
+ * Line and column numbers returned as part of this are zero based.
  */
 export abstract class BaseError extends Error {
   public line: { start: number; end: number } | undefined;
@@ -93,7 +94,8 @@ export abstract class BaseMultiError<T = BaseError> extends Error {
 }
 
 /**
- * Added to listener during syntax parsing, when syntax errors are encountered
+ * Added to listener during syntax parsing, when syntax errors are encountered.
+ * Line and column numbers returned as part of this are zero based.
  */
 export class DSLSyntaxSingleError extends BaseError {
   constructor(
@@ -122,6 +124,7 @@ export class DSLSyntaxError extends BaseMultiError<DSLSyntaxSingleError> {}
 
 /**
  * Added to reporter as the JSON transformation is being parsed and validated
+ * Line and column numbers returned as part of this are zero based.
  */
 export class ModelValidationSingleError extends BaseError {
   constructor(
@@ -179,7 +182,7 @@ export class ConditionNameDoesntMatchError extends Error {
 
 /**
  * Represents an individual error returned during validation of `fga.mod`.
- * Line and column numbers returned as part of this are one based.
+ * Line and column numbers returned as part of this are zero based.
  */
 export class FGAModFileValidationSingleError extends BaseError {
   constructor(public properties: ErrorProperties) {
@@ -198,7 +201,7 @@ export class FGAModFileValidationError extends BaseMultiError {}
 
 /*
  * Represents an individual error returned during transformation of a module.
- * Line and column numbers returned as part of this are one based.
+ * Line and column numbers returned as part of this are zero based.
  */
 export class ModuleTransformationSingleError extends BaseError {
   constructor(

--- a/pkg/js/transformer/dsltojson.ts
+++ b/pkg/js/transformer/dsltojson.ts
@@ -400,8 +400,8 @@ class OpenFgaDslErrorListener<T> extends ErrorListener<T> {
   syntaxError(
     _recognizer: Recognizer<T>,
     offendingSymbol: T,
-    line: number,
-    column: number,
+    line: number, // line is one based, i.e. the first line will be 1
+    column: number, // column is zero based, i.e. the first column will be 0
     msg: string,
     e: RecognitionException | undefined,
   ) {

--- a/pkg/js/transformer/dsltojson.ts
+++ b/pkg/js/transformer/dsltojson.ts
@@ -418,7 +418,7 @@ class OpenFgaDslErrorListener<T> extends ErrorListener<T> {
     this.errors.push(
       new DSLSyntaxSingleError(
         {
-          line: { start: line, end: line },
+          line: { start: line - 1, end: line - 1 },
           column: { start: column, end: column + columnOffset },
           msg,
         },

--- a/pkg/js/transformer/modules/mod-to-json.ts
+++ b/pkg/js/transformer/modules/mod-to-json.ts
@@ -53,7 +53,7 @@ function getLineAndColumnFromLinePos(linePos?: [LinePos] | [LinePos, LinePos]): 
   column: { start: number; end: number };
 } {
   if (linePos === undefined) {
-    return { line: { start: 1, end: 1 }, column: { start: 1, end: 1 } };
+    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
   }
   // eslint-disable-next-line prefer-const
   let [start, end] = linePos;
@@ -83,19 +83,19 @@ function getLineAndColumnFromNode(
   counter: LineCounter,
 ): { line: { start: number; end: number }; column: { start: number; end: number } } {
   if (!isNode(node) || !node.range) {
-    return { line: { start: 1, end: 1 }, column: { start: 1, end: 1 } };
+    return { line: { start: 0, end: 0 }, column: { start: 0, end: 0 } };
   }
 
   const start = counter.linePos(node.range[0]);
   const end = counter.linePos(node.range[1]);
   return {
     line: {
-      start: start.line,
-      end: end.line,
+      start: start.line - 1,
+      end: end.line - 1,
     },
     column: {
-      start: start.col,
-      end: end.col,
+      start: start.col - 1,
+      end: end.col - 1,
     },
   };
 }

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -226,7 +226,7 @@ export const transformModuleFilesToModel = (
         const line = lines[lineIndex];
         const wordIndex = resolveWordIndex(e, line);
 
-        e.line = { start: lineIndex + 1, end: lineIndex + 1 };
+        e.line = { start: lineIndex, end: lineIndex };
         e.column = { start: wordIndex, end: wordIndex + (e.metadata.symbol?.length || 0) };
         errors.push(e);
       }
@@ -299,20 +299,17 @@ function resolveWordIndex(e: ModelValidationSingleError, line: string): number {
 
   let wordIdx;
   switch (metadata.errorType) {
-    case ValidationError.ConditionNotDefined:
-      wordIdx = line.indexOf(metadata.symbol.substring(1));
-      break;
     case ValidationError.TuplesetNotDirect:
-      const clauseStartsAt = line.indexOf("from") + "from".length + 1;
-      wordIdx = clauseStartsAt + line.slice(clauseStartsAt).indexOf(metadata.symbol) + 1;
+      const clauseStartsAt = line.indexOf("from") + "from".length;
+      wordIdx = clauseStartsAt + line.slice(clauseStartsAt).indexOf(metadata.symbol);
       break;
     default:
       const re = new RegExp("\\b" + metadata.symbol + "\\b");
-      wordIdx = line?.search(re) + 1;
+      wordIdx = line?.search(re);
   }
 
-  if (wordIdx == undefined || isNaN(wordIdx) || wordIdx === 0) {
-    wordIdx = 1;
+  if (wordIdx == undefined || isNaN(wordIdx) || wordIdx === -1) {
+    wordIdx = 0;
   }
 
   return wordIdx;

--- a/pkg/js/util/exceptions.ts
+++ b/pkg/js/util/exceptions.ts
@@ -82,8 +82,8 @@ const createTupleUsersetRequireDirectError = (props: BaseProps) => {
       lines,
       lineIndex,
       customResolver: (wordIdx, rawLine, value) => {
-        const clauseStartsAt = rawLine.indexOf("from") + "from".length + 1;
-        wordIdx = clauseStartsAt + rawLine.slice(clauseStartsAt).indexOf(value) + 1;
+        const clauseStartsAt = rawLine.indexOf("from") + "from".length;
+        wordIdx = clauseStartsAt + rawLine.slice(clauseStartsAt).indexOf(value);
         return wordIdx;
       },
       metadata: { symbol, errorType: ValidationError.TuplesetNotDirect, file, module, typeName: type, relation },
@@ -228,9 +228,7 @@ const createAssignableRelationMustHaveTypesError = (props: BaseProps) => {
   }
 
   const rawLine = lines[lineIndex];
-  const actualValue = rawLine.includes("[")
-    ? rawLine.slice(rawLine.indexOf("["), rawLine.lastIndexOf("]") + 1)
-    : "self";
+  const actualValue = rawLine.includes("[") ? rawLine.slice(rawLine.indexOf("["), rawLine.lastIndexOf("]")) : "self";
 
   errors.push(
     constructValidationError({
@@ -304,12 +302,12 @@ const createDuplicateRelationshipDefinitionError = (props: BaseProps) => {
       {
         msg: `duplicate relationship definition \`${symbol}\`.`,
         line: {
-          start: lineIndex + 1,
-          end: lineIndex + 1,
+          start: lineIndex,
+          end: lineIndex,
         },
         column: {
-          start: rawLine.indexOf(Keyword.DEFINE) + 1,
-          end: rawLine.length + 1,
+          start: rawLine.indexOf(Keyword.DEFINE),
+          end: rawLine.length,
         },
       },
       { symbol, errorType: ValidationError.DuplicatedError },
@@ -421,17 +419,17 @@ function constructValidationError(props: ValidationErrorProps): ModelValidationS
     const rawLine = lines[lineIndex];
 
     const re = new RegExp("\\b" + metadata.symbol + "\\b");
-    let wordIdx = rawLine?.search(re) + 1;
+    let wordIdx = rawLine?.search(re);
 
-    if (isNaN(wordIdx) || wordIdx === 0) {
-      wordIdx = 1;
+    if (isNaN(wordIdx) || wordIdx === -1) {
+      wordIdx = 0;
     }
 
     if (typeof customResolver === "function") {
       wordIdx = customResolver(wordIdx, rawLine, metadata.symbol);
     }
 
-    errorProps.line = { start: lineIndex + 1, end: lineIndex + 1 };
+    errorProps.line = { start: lineIndex, end: lineIndex };
     errorProps.column = { start: wordIdx, end: wordIdx + (metadata.symbol?.length || 0) };
   }
 
@@ -699,15 +697,15 @@ export function constructTransformationError(props: TransformationErrorProps) {
   const rawLine = lines[lineIndex];
 
   const re = new RegExp("\\b" + metadata.symbol + "\\b");
-  let wordIdx = rawLine?.search(re) + 1;
+  let wordIdx = rawLine?.search(re);
 
-  if (isNaN(wordIdx) || wordIdx === 0) {
-    wordIdx = 1;
+  if (isNaN(wordIdx) || wordIdx === -1) {
+    wordIdx = 0;
   }
 
   return new ModuleTransformationSingleError(
     {
-      line: { start: lineIndex + 1, end: lineIndex + 1 },
+      line: { start: lineIndex, end: lineIndex },
       column: { start: wordIdx, end: wordIdx + (metadata.symbol?.length || 0) },
       msg: message,
       file: metadata.file,

--- a/tests/data/dsl-semantic-validation-cases.yaml
+++ b/tests/data/dsl-semantic-validation-cases.yaml
@@ -11,11 +11,11 @@
   expected_errors:
     - msg: "the relation `allowed` does not exist."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 42
-        end: 49
+        start: 41
+        end: 48
       metadata:
         symbol: "allowed"
         errorType: missing-definition
@@ -30,11 +30,11 @@
   expected_errors:
     - msg: "a type cannot be named 'self' or 'this'."
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
-        start: 6
-        end: 10
+        start: 5
+        end: 9
       metadata:
         symbol: "self"
         errorType: reserved-type-keywords
@@ -49,11 +49,11 @@
   expected_errors:
     - msg: "a type cannot be named 'self' or 'this'."
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
-        start: 6
-        end: 10
+        start: 5
+        end: 9
       metadata:
         symbol: "this"
         errorType: reserved-type-keywords
@@ -68,11 +68,11 @@
   expected_errors:
     - msg: "a relation cannot be named 'self' or 'this'."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 16
+        start: 11
+        end: 15
       metadata:
         symbol: "self"
         errorType: reserved-relation-keywords
@@ -87,11 +87,11 @@
   expected_errors:
     - msg: "a relation cannot be named 'self' or 'this'."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 16
+        start: 11
+        end: 15
       metadata:
         symbol: "this"
         errorType: reserved-relation-keywords
@@ -111,11 +111,11 @@
         'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         does not match naming rule: '^[^:#@\s]{1,254}$'.
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
-        start: 6
-        end: 350
+        start: 5
+        end: 349
       metadata:
         symbol: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         errorType: invalid-name
@@ -133,11 +133,11 @@
         'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         of type 'org' does not match naming rule: '^[^:#@\s]{1,50}$'.
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 112
+        start: 11
+        end: 111
       metadata:
         symbol: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         errorType: invalid-name
@@ -157,21 +157,21 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `team` (no entrypoint)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         symbol: "viewer"
         errorType: relation-no-entry-point
     - msg: "`viewer` is an impossible relation for `group` (no entrypoint)."
       line:
-        start: 11
-        end: 11
+        start: 10
+        end: 10
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         symbol: "viewer"
         errorType: relation-no-entry-point
@@ -186,11 +186,11 @@
   expected_errors:
     - msg: "`group` is an impossible relation for `group` (no entrypoint)."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 17
+        start: 11
+        end: 16
       metadata:
         symbol: "group"
         errorType: relation-no-entry-point
@@ -206,11 +206,11 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `group` (no entrypoint)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         symbol: "viewer"
         errorType: relation-no-entry-point
@@ -224,11 +224,11 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `group` (no entrypoint)."
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         symbol: "viewer"
         errorType: relation-no-entry-point
@@ -244,11 +244,11 @@
   expected_errors:
     - msg: "the `reader` relation definition on type `group` is not valid: `reader` does not exist on `parent`, which is of type `group`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 38
+        start: 19
+        end: 37
       metadata:
         symbol: "reader from parent"
         errorType: invalid-relation-on-tupleset
@@ -263,11 +263,11 @@
   expected_errors:
     - msg: "`unknown` is not a valid type."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 21
-        end: 28
+        start: 20
+        end: 27
       metadata:
         errorType: invalid-type
 - name: from target relation is not a valid relation for the from child
@@ -283,11 +283,11 @@
   expected_errors:
     - msg: "`org` is not a valid relation for `group`."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 20
-        end: 35
+        start: 19
+        end: 34
       metadata:
         errorType: invalid-relation-type
 - name: org is not a relation for group
@@ -301,13 +301,14 @@
         define parent: [group]
         define viewer: org from parent
   expected_errors:
-    - msg: "the `org` relation definition on type `group` is not valid: `org` does not exist on `parent`, which is of type `group`."
+    - msg: "the `org` relation definition on type `group` is not valid: `org` does not
+        exist on `parent`, which is of type `group`."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 20
-        end: 35
+        start: 19
+        end: 34
       metadata:
         errorType: invalid-relation-on-tupleset
 - name: direct relation assignment not found
@@ -322,11 +323,11 @@
   expected_errors:
     - msg: "`org` is not a valid relation for `group`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 28
-        end: 37
+        start: 27
+        end: 36
       metadata:
         errorType: invalid-relation-type
 - name: group viewer no entry point
@@ -344,11 +345,11 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `group` (no entrypoint)."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
 - name: cyclic loop
@@ -362,20 +363,20 @@
   expected_errors:
     - msg: "`reader` is an impossible relation for `document` (potential loop)."
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
     - msg: "`writer` is an impossible relation for `document` (potential loop)."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
 - name: parent relation used inside contains a write
@@ -390,21 +391,21 @@
   expected_errors:
     - msg: "`parent` relation used inside from allows only direct relation."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 44
-        end: 50
+        start: 43
+        end: 49
       metadata:
-        symbol: "parent"
+        symbol: parent
         errorType: tupleuserset-not-direct
     - msg: "`parent` relation used inside from allows only direct relation."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 42
-        end: 48
+        start: 41
+        end: 47
       metadata:
         symbol: "parent"
         errorType: tupleuserset-not-direct
@@ -421,11 +422,11 @@
   expected_errors:
     - msg: "`parent` relation used inside from allows only direct relation."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 42
-        end: 48
+        start: 41
+        end: 47
       metadata:
         symbol: "parent"
         errorType: tupleuserset-not-direct
@@ -442,11 +443,11 @@
   expected_errors:
     - msg: "`parent` relation used inside from allows only direct relation."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 42
-        end: 48
+        start: 41
+        end: 47
       metadata:
         symbol: "parent"
         errorType: tupleuserset-not-direct
@@ -462,11 +463,11 @@
   expected_errors:
     - msg: "the relation `allowed` does not exist."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 31
-        end: 38
+        start: 30
+        end: 37
       metadata:
         symbol: "allowed"
         errorType: missing-definition
@@ -482,11 +483,11 @@
   expected_errors:
     - msg: "the relation `allowed` does not exist."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 30
-        end: 37
+        start: 29
+        end: 36
       metadata:
         symbol: "allowed"
         errorType: missing-definition
@@ -502,11 +503,11 @@
   expected_errors:
     - msg: "the relation `allowed` does not exist."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 27
+        start: 19
+        end: 26
       metadata:
         symbol: "allowed"
         errorType: missing-definition
@@ -522,11 +523,11 @@
   expected_errors:
     - msg: "the relation `allowed` does not exist."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 35
-        end: 42
+        start: 34
+        end: 41
       metadata:
         symbol: "allowed"
         errorType: missing-definition
@@ -544,29 +545,29 @@
   expected_errors:
     - msg: "`action1` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
     - msg: "`action2` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
     - msg: "`action3` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
 - name: no entry point exclusion that relates to itself
@@ -583,29 +584,29 @@
   expected_errors:
     - msg: "`action1` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
     - msg: "`action2` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
     - msg: "`action3` is an impossible relation for `doc` (potential loop)."
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
-        start: 12
-        end: 19
+        start: 11
+        end: 18
       metadata:
         errorType: relation-no-entry-point
 - name: intersection child not allow to reference itself in TTU
@@ -620,11 +621,11 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `document` (no entrypoint)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
 - name: exclusion base not allow to reference itself in TTU
@@ -639,11 +640,11 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `document` (no entrypoint)."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
 - name: detect loop in TTU dependency
@@ -661,20 +662,20 @@
   expected_errors:
     - msg: "`viewer` is an impossible relation for `folder` (no entrypoint)."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
     - msg: "`viewer` is an impossible relation for `document` (no entrypoint)."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 12
-        end: 18
+        start: 11
+        end: 17
       metadata:
         errorType: relation-no-entry-point
 - name: model 1.1 should raise error if none of the children has such relation
@@ -697,38 +698,38 @@
   expected_errors:
     - msg: "the `u3` relation definition on type `final` is not valid: `u3` does not exist on `children`, which is of type `child1`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 26
-        end: 42
+        start: 25
+        end: 41
       metadata:
         errorType: invalid-relation-on-tupleset
     - msg: "the `u3` relation definition on type `final` is not valid: `u3` does not exist on `children`, which is of type `child2`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 26
-        end: 42
+        start: 25
+        end: 41
       metadata:
         errorType: invalid-relation-on-tupleset
     - msg: "the `u2` relation definition on type `final` is not valid: `u2` does not exist on `children`, which is of type `child1`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 46
-        end: 62
+        start: 45
+        end: 61
       metadata:
         errorType: invalid-relation-on-tupleset
     - msg: "the `u2` relation definition on type `final` is not valid: `u2` does not exist on `children`, which is of type `child2`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 46
-        end: 62
+        start: 45
+        end: 61
       metadata:
         errorType: invalid-relation-on-tupleset
 - name: self reference with wildcard
@@ -743,11 +744,11 @@
   expected_errors:
     - msg: "`parent` relation used inside from allows only direct relation."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 42
-        end: 48
+        start: 41
+        end: 47
       metadata:
         symbol: "parent"
         errorType: tupleuserset-not-direct
@@ -760,15 +761,14 @@
   expected_errors:
     - msg: "the type `user` is a duplicate."
       line:
-        start: 3
-        end: 3
+        start: 2
+        end: 2
       column:
-        start: 6
-        end: 10
+        start: 5
+        end: 9
       metadata:
         symbol: "user"
         errorType: duplicated-error
-
 - name: duplicate type in relations
   dsl: |
     model
@@ -780,11 +780,11 @@
   expected_errors:
     - msg: "the type restriction `user` is a duplicate in the relation `viewer`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 21
-        end: 25
+        start: 20
+        end: 24
       metadata:
         symbol: "user"
         errorType: duplicated-error
@@ -802,11 +802,11 @@
   expected_errors:
     - msg: "the type restriction `group#member` is a duplicate in the relation `viewer`."
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
-        start: 21
-        end: 33
+        start: 20
+        end: 32
       metadata:
         symbol: "group#member"
         errorType: duplicated-error
@@ -821,11 +821,11 @@
   expected_errors:
     - msg: "the type restriction `user:*` is a duplicate in the relation `viewer`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 21
-        end: 27
+        start: 20
+        end: 26
       metadata:
         symbol: "user:*"
         errorType: duplicated-error
@@ -841,11 +841,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `editor`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -861,11 +861,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `editor`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -881,11 +881,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `editor`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -900,11 +900,11 @@
   expected_errors:
     - msg: "the type restriction `user` is a duplicate in the relation `member`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 21
-        end: 25
+        start: 20
+        end: 24
       metadata:
         symbol: "user"
         errorType: duplicated-error
@@ -919,11 +919,11 @@
   expected_errors:
     - msg: "the type restriction `user:*` is a duplicate in the relation `member`."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 21
-        end: 27
+        start: 20
+        end: 26
       metadata:
         symbol: "user:*"
         errorType: duplicated-error
@@ -939,11 +939,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `member`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -959,11 +959,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `member`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -979,11 +979,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer` is a duplicate in the relation `member`."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 20
-        end: 26
+        start: 19
+        end: 25
       metadata:
         symbol: "viewer"
         errorType: duplicated-error
@@ -1002,11 +1002,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer from parent` is a duplicate in the relation `viewer`."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 20
-        end: 38
+        start: 19
+        end: 37
       metadata:
         symbol: "viewer from parent"
         errorType: duplicated-error
@@ -1025,11 +1025,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer from parent` is a duplicate in the relation `viewer`."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 20
-        end: 38
+        start: 19
+        end: 37
       metadata:
         symbol: "viewer from parent"
         errorType: duplicated-error
@@ -1048,11 +1048,11 @@
   expected_errors:
     - msg: "the partial relation definition `viewer from parent` is a duplicate in the relation `viewer`."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 20
-        end: 38
+        start: 19
+        end: 37
       metadata:
         symbol: "viewer from parent"
         errorType: duplicated-error
@@ -1079,15 +1079,14 @@
   expected_errors:
     - msg: "the type `account` is a duplicate."
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
-        start: 6
-        end: 13
+        start: 5
+        end: 12
       metadata:
         symbol: "account"
         errorType: duplicated-error
-## Conditions
 - name: condition not defined - single character
   dsl: |
     model
@@ -1101,11 +1100,11 @@
   expected_errors:
     - msg: "`c` is not a defined condition in the model."
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
-        start: 31
-        end: 32
+        start: 30
+        end: 31
       metadata:
         symbol: "c"
         errorType: condition-not-defined
@@ -1120,11 +1119,11 @@
   expected_errors:
     - msg: "`allowed_ip` is not a defined condition in the model."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 31
-        end: 41
+        start: 30
+        end: 40
       metadata:
         symbol: "allowed_ip"
         errorType: condition-not-defined
@@ -1143,11 +1142,11 @@
   expected_errors:
     - msg: "`allowed_ip` is not a defined condition in the model."
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
-        start: 31
-        end: 41
+        start: 30
+        end: 40
       metadata:
         symbol: "allowed_ip"
         errorType: condition-not-defined
@@ -1165,11 +1164,11 @@
   expected_errors:
     - msg: "`allowed_ip` condition is not used in the model."
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
-        start: 11
-        end: 21
+        start: 10
+        end: 20
       metadata:
         symbol: "allowed_ip"
         errorType: condition-not-used
@@ -1184,11 +1183,11 @@
   expected_errors:
     - msg: "invalid schema 0.9"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
-        start: 10
-        end: 13
+        start: 9
+        end: 12
       metadata:
         errorType: invalid-schema
 - name: supports parsing a modular model but throws schema required error
@@ -1198,14 +1197,13 @@
   expected_errors:
     - msg: schema version required
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       metadata:
         errorType: schema-version-required
-
 - name: allows extend in modular model
   dsl: |
     module foo
@@ -1214,11 +1212,11 @@
   expected_errors:
     - msg: schema version required
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       metadata:
         errorType: schema-version-required
 #- name: invalid cel expression

--- a/tests/data/dsl-syntax-validation-cases.yaml
+++ b/tests/data/dsl-syntax-validation-cases.yaml
@@ -20,15 +20,14 @@
         define viewer: [user]   
           
         define can_view: viewer or admin
-
 - name: no model header
   dsl: |
     type user
   expected_errors:
     - msg: "extraneous input 'type' expecting {WHITESPACE, '#', 'module', 'model', NEWLINE}"
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
         start: 0
         end: 4
@@ -36,8 +35,8 @@
         symbol: "type"
     - msg: "extraneous input 'user' expecting {'#', 'module', 'model', NEWLINE}"
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
         start: 5
         end: 9
@@ -45,8 +44,8 @@
         symbol: "user"
     - msg: "mismatched input '<EOF>' expecting {'#', 'module', 'model'}"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 0
         end: 5
@@ -59,8 +58,8 @@
   expected_errors:
     - msg: "mismatched input 'type' expecting 'schema'"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 0
         end: 4
@@ -73,8 +72,8 @@
   expected_errors:
     - msg: "mismatched input 'schema1' expecting 'schema'"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 2
         end: 9
@@ -87,8 +86,8 @@
   expected_errors:
     - msg: "mismatched input '11' expecting SCHEMA_VERSION"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 9
         end: 11
@@ -101,8 +100,8 @@
   expected_errors:
     - msg: "mismatched input 'a' expecting SCHEMA_VERSION"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 9
         end: 10
@@ -118,8 +117,8 @@
   expected_errors:
     - msg: "no viable alternative at input '\\n  define'"
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 2
         end: 8
@@ -138,8 +137,8 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 38
         end: 39
@@ -158,8 +157,8 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 56
         end: 57
@@ -178,8 +177,8 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 56
         end: 57
@@ -199,8 +198,8 @@
   expected_errors:
     - msg: "extraneous input 'but not' expecting {')', WHITESPACE}"
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
         start: 91
         end: 98
@@ -208,8 +207,8 @@
         symbol: "but not"
     - msg: "extraneous input 'baz' expecting {')', WHITESPACE}"
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
         start: 99
         end: 102
@@ -228,8 +227,8 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 38
         end: 39
@@ -248,8 +247,8 @@
   expected_errors:
     - msg: "extraneous input 'but not' expecting {')', WHITESPACE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 56
         end: 63
@@ -257,8 +256,8 @@
         symbol: "but not"
     - msg: "extraneous input 'restricted' expecting {')', WHITESPACE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 64
         end: 74
@@ -275,8 +274,8 @@
   expected_errors:
     - msg: "no viable alternative at input '\\n    defne'"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 4
         end: 9
@@ -307,8 +306,8 @@
   expected_errors:
     - msg: "'viewer' is already defined in 'document'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 11
         end: 17
@@ -329,8 +328,8 @@
   expected_errors:
     - msg: "missing ':' at 'as'"
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
         start: 18
         end: 20
@@ -338,8 +337,8 @@
         symbol: "as"
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
         start: 20
         end: 21
@@ -357,17 +356,18 @@
   expected_errors:
     - msg: "extraneous input ']' expecting {IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation', NEWLINE}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 21
         end: 22
       metadata:
         symbol: "]"
-    - msg: "mismatched input 'define' expecting {IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
+    - msg: mismatched input 'define' expecting {IDENTIFIER, 'module', 'model',
+        'schema', 'extend', 'type', 'relation'}
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 4
         end: 10
@@ -375,13 +375,13 @@
         symbol: "define"
     - msg: "mismatched input 'reader' expecting {',', ']'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 11
         end: 17
       metadata:
-        symbol: "reader"
+        symbol: reader
 - name: empty directly assignable relations without spaces should yield error
   dsl: |
     model
@@ -394,8 +394,8 @@
   expected_errors:
     - msg: "extraneous input ']' expecting {WHITESPACE, IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation', NEWLINE}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 20
         end: 21
@@ -403,8 +403,8 @@
         symbol: "]"
     - msg: "mismatched input 'define' expecting {IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 4
         end: 10
@@ -412,8 +412,8 @@
         symbol: "define"
     - msg: "mismatched input 'reader' expecting {',', ']'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 11
         end: 17
@@ -431,8 +431,8 @@
   expected_errors:
     - msg: "missing ':' at 'as'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 18
         end: 20
@@ -440,8 +440,8 @@
         symbol: "as"
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 20
         end: 21
@@ -461,8 +461,8 @@
   expected_errors:
     - msg: "missing ':' at 'as'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 18
         end: 20
@@ -470,8 +470,8 @@
         symbol: "as"
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 20
         end: 21
@@ -486,8 +486,8 @@
   expected_errors:
     - msg: "extraneous input 'type' expecting {WHITESPACE, '#', 'module', 'model', NEWLINE}"
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
         start: 0
         end: 4
@@ -495,8 +495,8 @@
         symbol: "type"
     - msg: "extraneous input 'user' expecting {'#', 'module', 'model', NEWLINE}"
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
         start: 5
         end: 9
@@ -504,8 +504,8 @@
         symbol: "user"
     - msg: "mismatched input 'type' expecting {'#', 'module', 'model'}"
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
         start: 0
         end: 4
@@ -522,8 +522,8 @@
   expected_errors:
     - msg: "mismatched input ':' expecting {',', WHITESPACE, ']'}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 32
         end: 33
@@ -541,8 +541,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 34
         end: 35
@@ -550,8 +550,8 @@
         symbol: "["
     - msg: "mismatched input '#' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 43
         end: 44
@@ -568,8 +568,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 40
         end: 41
@@ -577,8 +577,8 @@
         symbol: "["
     - msg: "mismatched input '#' expecting {<EOF>, NEWLINE}"
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 49
         end: 50
@@ -596,8 +596,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 30
         end: 31
@@ -605,8 +605,8 @@
         symbol: "["
     - msg: "mismatched input '#' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 39
         end: 40
@@ -624,8 +624,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 45
         end: 46
@@ -633,8 +633,8 @@
         symbol: "["
     - msg: "extraneous input ']' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 50
         end: 51
@@ -652,8 +652,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 34
         end: 35
@@ -661,8 +661,8 @@
         symbol: "["
     - msg: "mismatched input '#' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 43
         end: 44
@@ -680,8 +680,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 29
         end: 30
@@ -689,8 +689,8 @@
         symbol: "["
     - msg: "mismatched input '#' expecting {<EOF>, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 38
         end: 39
@@ -710,8 +710,8 @@
   expected_errors:
     - msg: "mismatched input ':' expecting {',', WHITESPACE, ']'}"
       line:
-        start: 9
-        end: 9
+        start: 8
+        end: 8
       column:
         start: 49
         end: 50
@@ -754,7 +754,6 @@
         define viewer: [user, org#member] or writer
   expected_errors: []
 - name: should allow directly assigned as last item
-
   dsl: |
     model
       schema 1.1
@@ -971,8 +970,8 @@
   expected_errors:
     - msg: "mismatched input 'map' expecting CONDITION_PARAM_TYPE"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 37
         end: 40
@@ -992,8 +991,8 @@
   expected_errors:
     - msg: "mismatched input 'map' expecting CONDITION_PARAM_TYPE"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 38
         end: 41
@@ -1013,8 +1012,8 @@
   expected_errors:
     - msg: "mismatched input 'list' expecting CONDITION_PARAM_TYPE"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 37
         end: 41
@@ -1034,8 +1033,8 @@
   expected_errors:
     - msg: "mismatched input 'list' expecting CONDITION_PARAM_TYPE"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 38
         end: 42
@@ -1055,8 +1054,8 @@
   expected_errors:
     - msg: "mismatched input ')' expecting '<'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 37
         end: 38
@@ -1076,8 +1075,8 @@
   expected_errors:
     - msg: "mismatched input ')' expecting '<'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 36
         end: 37
@@ -1097,8 +1096,8 @@
   expected_errors:
     - msg: "mismatched input 'string' expecting {WHITESPACE, IDENTIFIER, NEWLINE}"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 25
         end: 31
@@ -1106,8 +1105,8 @@
         symbol: "string"
     - msg: "mismatched input 'status' expecting <EOF>"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 2
         end: 8
@@ -1130,8 +1129,8 @@
   expected_errors:
     - msg: "condition 'is_not_deleted' is already defined in the model"
       line:
-        start: 10
-        end: 10
+        start: 9
+        end: 9
       column:
         start: 10
         end: 24
@@ -1151,8 +1150,8 @@
   expected_errors:
     - msg: "parameter 'status' is already defined in the condition 'is_not_deleted'"
       line:
-        start: 7
-        end: 7
+        start: 6
+        end: 6
       column:
         start: 41
         end: 47
@@ -1212,8 +1211,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 29
         end: 30
@@ -1221,14 +1220,13 @@
         symbol: "["
     - msg: "extraneous input ']' expecting {<EOF>, NEWLINE}"
       line:
-        start: 5
-        end: 5
+        start: 4
+        end: 4
       column:
         start: 34
         end: 35
       metadata:
         symbol: "]"
-
 - name: an invalid model with confusing but not references
   dsl: |
     model
@@ -1242,14 +1240,13 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 34
         end: 35
       metadata:
         symbol: " "
-
 - name: an invalid model with mixed operators
   dsl: |
     model
@@ -1263,14 +1260,13 @@
   expected_errors:
     - msg: "mismatched input ' ' expecting {<EOF>, NEWLINE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 30
         end: 31
       metadata:
         symbol: " "
-
 - name: an invalid model x1
   dsl: |
     model
@@ -1282,8 +1278,8 @@
   expected_errors:
     - msg: "mismatched input 'but not' expecting {'[', '(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 17
         end: 24
@@ -1301,8 +1297,8 @@
   expected_errors:
     - msg: "mismatched input 'or' expecting {'[', '(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 17
         end: 19
@@ -1320,8 +1316,8 @@
   expected_errors:
     - msg: "mismatched input 'and' expecting {'[', '(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 17
         end: 20
@@ -1339,8 +1335,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 26
         end: 27
@@ -1348,8 +1344,8 @@
         symbol: "["
     - msg: "extraneous input ']' expecting {<EOF>, NEWLINE}"
       line:
-        start: 6
-        end: 6
+        start: 5
+        end: 5
       column:
         start: 31
         end: 32
@@ -1369,8 +1365,8 @@
   expected_errors:
     - msg: "extraneous input '[' expecting {'(', IDENTIFIER, 'module', 'model', 'schema', 'extend', 'type', 'relation'}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 54
         end: 55
@@ -1378,8 +1374,8 @@
         symbol: "["
     - msg: "extraneous input ']' expecting {')', WHITESPACE}"
       line:
-        start: 8
-        end: 8
+        start: 7
+        end: 7
       column:
         start: 59
         end: 60
@@ -1441,12 +1437,11 @@
   expected_errors:
     - msg: no viable alternative at input '\nmodule'
       line:
-        start: 3
-        end: 3
+        start: 2
+        end: 2
       column:
         start: 0
         end: 6
-
 - name: does not allow extend in model
   dsl: |
     model
@@ -1456,12 +1451,11 @@
   expected_errors:
     - msg: extend can only be used in a modular model
       line:
-        start: 4
-        end: 4
+        start: 3
+        end: 3
       column:
         start: 12
         end: 15
-
 - name: a valid model with type names doesn't conflict with built-in keywords
   dsl: |
     model

--- a/tests/data/fga-mod-transformer-cases.yaml
+++ b/tests/data/fga-mod-transformer-cases.yaml
@@ -12,12 +12,12 @@
       "schema": {
         "value": "1.2",
         "line": {
-          "start": 1,
-          "end": 1
+          "start": 0,
+          "end": 0
         },
         "column": {
-          "start": 9,
-          "end": 14
+          "start": 8,
+          "end": 13
         }
       },
       "contents": {
@@ -25,55 +25,55 @@
           {
             "value": "core.fga",
             "line": {
-              "start": 3,
-              "end": 3
+              "start": 2,
+              "end": 2
             },
             "column": {
-              "start": 5,
-              "end": 13
+              "start": 4,
+              "end": 12
             }
           },
           {
             "value": "team1/project.fga",
             "line": {
-              "start": 4,
-              "end": 4
+              "start": 3,
+              "end": 3
             },
             "column": {
-              "start": 5,
-              "end": 22
+              "start": 4,
+              "end": 21
             }
           },
           {
             "value": "team1/board.fga",
             "line": {
-              "start": 5,
-              "end": 5
+              "start": 4,
+              "end": 4
             },
             "column": {
-              "start": 5,
-              "end": 20
+              "start": 4,
+              "end": 19
             }
           },
           {
             "value": "wiki.fga",
             "line": {
-              "start": 6,
-              "end": 6
+              "start": 5,
+              "end": 5
             },
             "column": {
-              "start": 5,
-              "end": 13
+              "start": 4,
+              "end": 12
             }
           }
         ],
         "line": {
-          "start": 3,
-          "end": 7
+          "start": 2,
+          "end": 6
         },
         "column": {
-          "start": 3,
-          "end": 1
+          "start": 2,
+          "end": 0
         }
       }
     }
@@ -84,11 +84,11 @@
   expected_errors:
     - msg: missing schema field
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
 - name: invalid schema type
   modFile: |
     schema: true
@@ -97,11 +97,11 @@
   expected_errors:
     - msg: unexpected schema type, expected string got value true
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 9
-        end: 13
+        start: 8
+        end: 12
 - name: invalid schema version
   modFile: |
     schema: "1.1"
@@ -110,22 +110,22 @@
   expected_errors:
     - msg: unsupported schema version, fga.mod only supported in version `1.2`
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 9
-        end: 14
+        start: 8
+        end: 13
 - name: missing contents
   modFile: |
     schema: "1.2"
   expected_errors:
     - msg: missing contents field
       line:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
       column:
-        start: 1
-        end: 1
+        start: 0
+        end: 0
 - name: invalid contents type
   modFile: |
     schema: "1.2"
@@ -133,11 +133,11 @@
   expected_errors:
     - msg: unexpected contents type, expected list of strings got value true
       line:
-        start: 2
-        end: 2
+        start: 1
+        end: 1
       column:
-        start: 11
-        end: 15
+        start: 10
+        end: 14
 - name: contents is not a list of strings
   modFile: |
     schema: "1.2"
@@ -147,18 +147,18 @@
   expected_errors:
     - msg: unexpected contents item type, expected string got value true
       line:
+        start: 2
+        end: 2
+      column:
+        start: 4
+        end: 8
+    - msg: unexpected contents item type, expected string got value 1
+      line:
         start: 3
         end: 3
       column:
-        start: 5
-        end: 9
-    - msg: unexpected contents item type, expected string got value 1
-      line:
         start: 4
-        end: 4
-      column:
-        start: 5
-        end: 6
+        end: 5
 - name: contents item does not end with `.fga`
   modFile: |
     schema: "1.2"
@@ -167,8 +167,8 @@
   expected_errors:
     - msg: contents items should use fga file extension, got core.txt
       line:
-        start: 3
-        end: 3
+        start: 2
+        end: 2
       column:
-        start: 5
-        end: 13
+        start: 4
+        end: 12

--- a/tests/data/transformer-module/01-module-with-errors/expected_errors.json
+++ b/tests/data/transformer-module/01-module-with-errors/expected_errors.json
@@ -3,32 +3,32 @@
     "msg": "duplicate type definition user",
     "file": "org.fga",
     "line": {
-      "start": 3,
-      "end": 3
+      "start": 2,
+      "end": 2
     },
     "column": {
-      "start": 6,
-      "end": 10
+      "start": 5,
+      "end": 9
     }
   },
   {
     "msg": "duplicate condition a_check",
     "file": "org.fga",
     "line": {
-      "start": 15,
-      "end": 15
+      "start": 14,
+      "end": 14
     },
     "column": {
-      "start": 11,
-      "end": 18
+      "start": 10,
+      "end": 17
     }
   },
   {
     "msg": "no viable alternative at input '\\n  define'",
     "file": "syntax-error.fga",
     "line": {
-      "start": 4,
-      "end": 4
+      "start": 3,
+      "end": 3
     },
     "column": {
       "start": 2,
@@ -40,36 +40,36 @@
     "msg": "extended type noexist does not exist",
     "file": "org.fga",
     "line": {
-      "start": 9,
-      "end": 9
+      "start": 8,
+      "end": 8
     },
     "column": {
-      "start": 13,
-      "end": 20
+      "start": 12,
+      "end": 19
     }
   },
   {
     "msg": "relation foo already exists on type other",
     "file": "org.fga",
     "line": {
-      "start": 13,
-      "end": 13
+      "start": 12,
+      "end": 12
     },
     "column": {
-      "start": 12,
-      "end": 15
+      "start": 11,
+      "end": 14
     }
   },
   {
     "msg": "relation 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' of type 'other' does not match naming rule: '^[^:#@\\s]{1,50}$'.",
     "file": "core.fga",
     "line": {
-      "start": 8,
-      "end": 8
+      "start": 7,
+      "end": 7
     },
     "column": {
-      "start": 12,
-      "end": 112
+      "start": 11,
+      "end": 111
     },
     "metadata": {
       "errorType": "invalid-name"
@@ -79,12 +79,12 @@
     "msg": "a type cannot be named 'self' or 'this'.",
     "file": "core.fga",
     "line": {
-      "start": 10,
-      "end": 10
+      "start": 9,
+      "end": 9
     },
     "column": {
-      "start": 6,
-      "end": 10
+      "start": 5,
+      "end": 9
     },
     "metadata": {
       "errorType": "reserved-type-keywords"
@@ -94,12 +94,12 @@
     "msg": "a relation cannot be named 'self' or 'this'.",
     "file": "core.fga",
     "line": {
-      "start": 12,
-      "end": 12
+      "start": 11,
+      "end": 11
     },
     "column": {
-      "start": 12,
-      "end": 16
+      "start": 11,
+      "end": 15
     },
     "metadata": {
       "errorType": "reserved-relation-keywords"
@@ -109,12 +109,12 @@
     "msg": "type 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' does not match naming rule: '^[^:#@\\s]{1,254}$'.",
     "file": "core.fga",
     "line": {
-      "start": 14,
-      "end": 14
+      "start": 13,
+      "end": 13
     },
     "column": {
-      "start": 6,
-      "end": 350
+      "start": 5,
+      "end": 349
     },
     "metadata": {
       "errorType": "invalid-name"

--- a/tests/data/transformer-module/03-module-with-more-errors/expected_errors.json
+++ b/tests/data/transformer-module/03-module-with-more-errors/expected_errors.json
@@ -3,12 +3,12 @@
     "msg": "the relation `missing` does not exist.",
     "file": "core.fga",
     "line": {
-      "start": 7,
-      "end": 7
+      "start": 6,
+      "end": 6
     },
     "column": {
-      "start": 19,
-      "end": 26
+      "start": 18,
+      "end": 25
     },
     "metadata": {
       "errorType": "missing-definition"
@@ -18,12 +18,12 @@
     "msg": "`user` is not a valid relation for `org`.",
     "file": "core.fga",
     "line": {
-      "start": 8,
-      "end": 8
+      "start": 7,
+      "end": 7
     },
     "column": {
-      "start": 26,
-      "end": 41
+      "start": 25,
+      "end": 40
     },
     "metadata": {
       "errorType": "invalid-relation-type"
@@ -33,12 +33,12 @@
     "msg": "`unknown` is not a valid type.",
     "file": "core.fga",
     "line": {
-      "start": 9,
-      "end": 9
+      "start": 8,
+      "end": 8
     },
     "column": {
-      "start": 21,
-      "end": 28
+      "start": 20,
+      "end": 27
     },
     "metadata": {
       "errorType": "invalid-type"
@@ -48,12 +48,12 @@
     "msg": "`missing_condition` is not a defined condition in the model.",
     "file": "core.fga",
     "line": {
-      "start": 10,
-      "end": 10
+      "start": 9,
+      "end": 9
     },
     "column": {
-      "start": 31,
-      "end": 48
+      "start": 30,
+      "end": 47
     },
     "metadata": {
       "errorType": "condition-not-defined"
@@ -63,12 +63,12 @@
     "msg": "`manager` is not a valid relation for `user`.",
     "file": "core.fga",
     "line": {
-      "start": 11,
-      "end": 11
+      "start": 10,
+      "end": 10
     },
     "column": {
-      "start": 22,
-      "end": 34
+      "start": 21,
+      "end": 33
     },
     "metadata": {
       "errorType": "invalid-relation-type"
@@ -78,38 +78,8 @@
     "msg": "`parent` relation used inside from allows only direct relation.",
     "file": "core.fga",
     "line": {
-      "start": 15,
-      "end": 15
-    },
-    "column": {
-      "start": 43,
-      "end": 49
-    },
-    "metadata": {
-      "errorType": "tupleuserset-not-direct"
-    }
-  },
-  {
-    "msg": "`owner` relation used inside from allows only direct relation.",
-    "file": "org.fga",
-    "line": {
-      "start": 7,
-      "end": 7
-    },
-    "column": {
-      "start": 41,
-      "end": 46
-    },
-    "metadata": {
-      "errorType": "tupleuserset-not-direct"
-    }
-  },
-  {
-    "msg": "`parent` relation used inside from allows only direct relation.",
-    "file": "org.fga",
-    "line": {
-      "start": 13,
-      "end": 13
+      "start": 14,
+      "end": 14
     },
     "column": {
       "start": 42,
@@ -120,15 +90,45 @@
     }
   },
   {
+    "msg": "`owner` relation used inside from allows only direct relation.",
+    "file": "org.fga",
+    "line": {
+      "start": 6,
+      "end": 6
+    },
+    "column": {
+      "start": 40,
+      "end": 45
+    },
+    "metadata": {
+      "errorType": "tupleuserset-not-direct"
+    }
+  },
+  {
+    "msg": "`parent` relation used inside from allows only direct relation.",
+    "file": "org.fga",
+    "line": {
+      "start": 12,
+      "end": 12
+    },
+    "column": {
+      "start": 41,
+      "end": 47
+    },
+    "metadata": {
+      "errorType": "tupleuserset-not-direct"
+    }
+  },
+  {
     "msg": "`allowed_ip` condition is not used in the model.",
     "file": "core.fga",
     "line": {
-      "start": 18,
-      "end": 18
+      "start": 17,
+      "end": 17
     },
     "column": {
-      "start": 11,
-      "end": 21
+      "start": 10,
+      "end": 20
     },
     "metadata": {
       "errorType": "condition-not-used"

--- a/tests/data/transformer-module/04-module-with-even-more-errors/expected_errors.json
+++ b/tests/data/transformer-module/04-module-with-even-more-errors/expected_errors.json
@@ -3,12 +3,12 @@
     "msg": "`viewer` is an impossible relation for `team` (no entrypoint).",
     "file": "core.fga",
     "line": {
-      "start": 7,
-      "end": 7
+      "start": 6,
+      "end": 6
     },
     "column": {
-      "start": 12,
-      "end": 18
+      "start": 11,
+      "end": 17
     },
     "metadata": {
       "errorType": "relation-no-entry-point"
@@ -18,12 +18,12 @@
     "msg": "`viewer` is an impossible relation for `group` (no entrypoint).",
     "file": "core.fga",
     "line": {
-      "start": 11,
-      "end": 11
+      "start": 10,
+      "end": 10
     },
     "column": {
-      "start": 12,
-      "end": 18
+      "start": 11,
+      "end": 17
     },
     "metadata": {
       "errorType": "relation-no-entry-point"
@@ -33,12 +33,12 @@
     "msg": "`reader` is an impossible relation for `document` (potential loop).",
     "file": "core.fga",
     "line": {
-      "start": 15,
-      "end": 15
+      "start": 14,
+      "end": 14
     },
     "column": {
-      "start": 12,
-      "end": 18
+      "start": 11,
+      "end": 17
     },
     "metadata": {
       "errorType": "relation-no-entry-point"
@@ -48,12 +48,12 @@
     "msg": "`writer` is an impossible relation for `document` (potential loop).",
     "file": "core.fga",
     "line": {
-      "start": 16,
-      "end": 16
+      "start": 15,
+      "end": 15
     },
     "column": {
-      "start": 12,
-      "end": 18
+      "start": 11,
+      "end": 17
     },
     "metadata": {
       "errorType": "relation-no-entry-point"

--- a/tests/data/transformer-module/05-module-with-relation-errors/expected_errors.json
+++ b/tests/data/transformer-module/05-module-with-relation-errors/expected_errors.json
@@ -3,12 +3,12 @@
     "msg": "the `can_manage` relation definition on type `employe` is not valid: `can_manage` does not exist on `manager`, which is of type `employee`.",
     "file": "employee.fga",
     "line": {
-      "start": 5,
-      "end": 5
+      "start": 4,
+      "end": 4
     },
     "column": {
-      "start": 35,
-      "end": 58
+      "start": 34,
+      "end": 57
     },
     "metadata": {
       "errorType": "invalid-relation-on-tupleset"
@@ -18,12 +18,12 @@
     "msg": "`employee` is not a valid type.",
     "file": "employee.fga",
     "line": {
-      "start": 6,
-      "end": 6
+      "start": 5,
+      "end": 5
     },
     "column": {
-      "start": 22,
-      "end": 30
+      "start": 21,
+      "end": 29
     },
     "metadata": {
       "errorType": "invalid-type"


### PR DESCRIPTION
## Description

Makes the line and column numbers for the various errors 0 based, we were mostly 1 based already with the exception of some oversights (Go default error in some modular cases) and the line (but not column) on syntax errors from antlr.

This is separated into different commits for the tests and each language to help with review. There is a little bit of awkwardness in that we don't assert the errors in Go and Java due to differences in the errors across languages, but it shouldn't be an issue.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
