### PR TITLE
feat(java): implement fga.mod transformer

### DIFF
--- a/pkg/java/build.gradle
+++ b/pkg/java/build.gradle
@@ -75,9 +75,9 @@ dependencies {
     implementation 'org.antlr:antlr4:4.13.1'
     implementation 'dev.openfga:openfga-sdk:0.3.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3'
 }
 
 spotless {

--- a/pkg/java/src/main/java/dev/openfga/language/FgaModFile.java
+++ b/pkg/java/src/main/java/dev/openfga/language/FgaModFile.java
@@ -1,0 +1,37 @@
+package dev.openfga.language;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FgaModFile {
+
+    public static final String JSON_PROPERTY_SCHEMA = "schema";
+    private ModFileStringProperty schema;
+
+    public static final String JSON_PROPERTY_CONTENTS = "contents";
+    private ModFileArrayProperty contents;
+
+    public FgaModFile() {}
+
+    public FgaModFile schema(ModFileStringProperty schema) {
+        this.schema = schema;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_SCHEMA)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public ModFileStringProperty getSchema() {
+        return this.schema;
+    }
+
+    public FgaModFile contents(ModFileArrayProperty contents) {
+        this.contents = contents;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_CONTENTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public ModFileArrayProperty getContents() {
+        return this.contents;
+    }
+}

--- a/pkg/java/src/main/java/dev/openfga/language/FgaModTransformer.java
+++ b/pkg/java/src/main/java/dev/openfga/language/FgaModTransformer.java
@@ -1,0 +1,173 @@
+package dev.openfga.language;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import dev.openfga.language.errors.ErrorProperties;
+import dev.openfga.language.errors.ModFileValidationError;
+import dev.openfga.language.errors.ModFileValidationSingleError;
+import dev.openfga.language.errors.StartEnd;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FgaModTransformer {
+
+    private final List<ModFileValidationSingleError> errors = new ArrayList<ModFileValidationSingleError>();
+    private String modFileContents;
+
+    public FgaModTransformer(String modFileContents) {
+        this.modFileContents = modFileContents;
+    }
+
+    public static String transform(String modFileContents)
+            throws IOException, JsonProcessingException, ModFileValidationError {
+        return JSON.stringify(parse(modFileContents));
+    }
+
+    public static FgaModFile parse(String modFileContents)
+            throws IOException, JsonProcessingException, ModFileValidationError {
+        return new FgaModTransformer(modFileContents).parse();
+    }
+
+    public FgaModFile parse() throws IOException, JsonProcessingException, ModFileValidationError {
+        YAMLParser parser = new YAMLFactory().createParser(modFileContents);
+        FgaModFile modFile = new FgaModFile();
+        ArrayList<String> seenFields = new ArrayList<String>();
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            JsonToken currentToken = parser.currentToken();
+            String name = parser.getCurrentName();
+
+            if (currentToken != JsonToken.FIELD_NAME) {
+                continue;
+            }
+
+            parser.nextToken();
+            currentToken = parser.currentToken();
+            JsonLocation location = parser.getCurrentLocation();
+
+            if (name.equals("schema")) {
+                seenFields.add("schema");
+                handleSchema(parser, modFile, currentToken, location);
+            } else if (name.equals("contents")) {
+                seenFields.add("contents");
+                handleContents(parser, modFile, currentToken, location);
+            }
+        }
+
+        if (!seenFields.contains("schema")) {
+            addError("missing schema field", new StartEnd(0, 0), new StartEnd(0, 0));
+        }
+
+        if (!seenFields.contains("contents")) {
+            addError("missing contents field", new StartEnd(0, 0), new StartEnd(0, 0));
+        }
+
+        if (!errors.isEmpty()) {
+            throw new ModFileValidationError(errors);
+        }
+
+        return modFile;
+    }
+
+    private void handleSchema(YAMLParser parser, FgaModFile modFile, JsonToken currentToken, JsonLocation location)
+            throws IOException {
+        String value = parser.getText();
+
+        if (currentToken != JsonToken.VALUE_STRING) {
+            StartEnd line = getLine(location);
+            StartEnd column = getColumn(location, value);
+            addError("unexpected schema type, expected string got value " + value, line, column);
+        } else if (!value.equals("1.2")) {
+            StartEnd line = getLine(location);
+            StartEnd column = getColumn(location, "\"" + value + "\"");
+            addError("unsupported schema version, fga.mod only supported in version `1.2`", line, column);
+        } else {
+            StartEnd line = getLine(location);
+            // We have to wrap our value in quotes here as
+            StartEnd column = getColumn(location, "\"" + value + "\"");
+
+            ModFileStringProperty p =
+                    new ModFileStringProperty().value(value).line(line).column(column);
+            modFile.schema(p);
+        }
+    }
+
+    private void handleContents(
+            YAMLParser parser, FgaModFile modFile, JsonToken currentToken, JsonLocation startLocation)
+            throws IOException {
+        ModFileArrayProperty p = new ModFileArrayProperty();
+
+        if (currentToken != JsonToken.START_ARRAY) {
+            String value = parser.getText();
+            StartEnd line = getLine(startLocation);
+            StartEnd column = getColumn(startLocation, value);
+            addError("unexpected contents type, expected list of strings got value " + value, line, column);
+            return;
+        }
+
+        List<ModFileStringProperty> contents = new ArrayList<ModFileStringProperty>();
+        while (parser.nextToken() != JsonToken.END_ARRAY) {
+            currentToken = parser.currentToken();
+            JsonLocation currentLoc = parser.getCurrentLocation();
+            String rawValue = parser.getValueAsString();
+
+            StartEnd line = getLine(currentLoc);
+            StartEnd column = getColumn(currentLoc, rawValue);
+
+            if (currentToken != JsonToken.VALUE_STRING) {
+                addError("unexpected contents item type, expected string got value " + rawValue, line, column);
+                continue;
+            }
+
+            String value = URLDecoder.decode(rawValue, "utf-8");
+
+            value = value.replaceAll("\\\\", "/");
+
+            if (value.contains("../") || value.startsWith("/")) {
+                addError("invalid contents item " + rawValue, line, column);
+                continue;
+            }
+
+            if (!value.endsWith(".fga")) {
+                addError("contents items should use fga file extension, got " + value, line, column);
+                continue;
+            }
+
+            contents.add(new ModFileStringProperty().value(value).line(line).column(column));
+        }
+        JsonLocation endLoc = parser.getCurrentLocation();
+
+        p.line(new StartEnd(startLocation.getLineNr() - 1, endLoc.getLineNr() - 1))
+                .column(new StartEnd(startLocation.getColumnNr() - 1, endLoc.getColumnNr() - 1))
+                .value(contents);
+
+        modFile.contents(p);
+    }
+
+    private StartEnd getLine(JsonLocation loc) {
+        Integer line = loc.getLineNr() - 1;
+        return new StartEnd(line, line);
+    }
+
+    private StartEnd getColumn(JsonLocation loc, String text) {
+        // As the yaml parser does not expose an easy way of checking if the value is wrapped in
+        // in quotes, scan the modFile string to see if it is and add an offset to the string length.
+        Integer quotesOffset = 0;
+        if (modFileContents.contains("'" + text + "'") || modFileContents.contains("\"" + text + "\"")) {
+            quotesOffset = 2;
+        }
+
+        Integer columnEnd = loc.getColumnNr() - 1;
+        Integer columnStart = columnEnd - (text.length() + quotesOffset);
+        return new StartEnd(columnStart, columnEnd);
+    }
+
+    private void addError(String message, StartEnd line, StartEnd column) {
+        errors.add(new ModFileValidationSingleError(new ErrorProperties(line, column, message)));
+    }
+}

--- a/pkg/java/src/main/java/dev/openfga/language/ModFileArrayProperty.java
+++ b/pkg/java/src/main/java/dev/openfga/language/ModFileArrayProperty.java
@@ -1,0 +1,52 @@
+package dev.openfga.language;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.openfga.language.errors.StartEnd;
+import java.util.List;
+
+public class ModFileArrayProperty {
+    public static final String JSON_PROPERTY_VALUE = "value";
+    private List<ModFileStringProperty> value;
+
+    public static final String JSON_PROPERTY_LINE = "line";
+    private StartEnd line;
+
+    public static final String JSON_PROPERTY_COLUMN = "column";
+    private StartEnd column;
+
+    public ModFileArrayProperty() {}
+
+    @JsonProperty(JSON_PROPERTY_VALUE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public List<ModFileStringProperty> getValue() {
+        return value;
+    }
+
+    public ModFileArrayProperty value(List<ModFileStringProperty> value) {
+        this.value = value;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_LINE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public StartEnd getLine() {
+        return line;
+    }
+
+    public ModFileArrayProperty line(StartEnd line) {
+        this.line = line;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_COLUMN)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public StartEnd getColumn() {
+        return column;
+    }
+
+    public ModFileArrayProperty column(StartEnd column) {
+        this.column = column;
+        return this;
+    }
+}

--- a/pkg/java/src/main/java/dev/openfga/language/ModFileStringProperty.java
+++ b/pkg/java/src/main/java/dev/openfga/language/ModFileStringProperty.java
@@ -1,0 +1,51 @@
+package dev.openfga.language;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.openfga.language.errors.StartEnd;
+
+public class ModFileStringProperty {
+    public static final String JSON_PROPERTY_VALUE = "value";
+    private String value;
+
+    public static final String JSON_PROPERTY_LINE = "line";
+    private StartEnd line;
+
+    public static final String JSON_PROPERTY_COLUMN = "column";
+    private StartEnd column;
+
+    public ModFileStringProperty() {}
+
+    @JsonProperty(JSON_PROPERTY_VALUE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public String getValue() {
+        return value;
+    }
+
+    public ModFileStringProperty value(String value) {
+        this.value = value;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_LINE)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public StartEnd getLine() {
+        return line;
+    }
+
+    public ModFileStringProperty line(StartEnd line) {
+        this.line = line;
+        return this;
+    }
+
+    @JsonProperty(JSON_PROPERTY_COLUMN)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    public StartEnd getColumn() {
+        return column;
+    }
+
+    public ModFileStringProperty column(StartEnd column) {
+        this.column = column;
+        return this;
+    }
+}

--- a/pkg/java/src/main/java/dev/openfga/language/errors/ModFileValidationError.java
+++ b/pkg/java/src/main/java/dev/openfga/language/errors/ModFileValidationError.java
@@ -1,0 +1,17 @@
+package dev.openfga.language.errors;
+
+import java.util.List;
+
+public class ModFileValidationError extends Exception {
+
+    private final List<ModFileValidationSingleError> errors;
+
+    public ModFileValidationError(List<ModFileValidationSingleError> errors) {
+        super(Errors.messagesFromErrors(errors));
+        this.errors = errors;
+    }
+
+    public List<ModFileValidationSingleError> getErrors() {
+        return errors;
+    }
+}

--- a/pkg/java/src/main/java/dev/openfga/language/errors/ModFileValidationSingleError.java
+++ b/pkg/java/src/main/java/dev/openfga/language/errors/ModFileValidationSingleError.java
@@ -1,0 +1,10 @@
+package dev.openfga.language.errors;
+
+public class ModFileValidationSingleError extends ParsingError {
+    // Needed for Jackson deserialization
+    public ModFileValidationSingleError() {}
+
+    public ModFileValidationSingleError(ErrorProperties properties) {
+        super("validation", properties);
+    }
+}

--- a/pkg/java/src/test/java/dev/openfga/language/FgaModToJsonShould.java
+++ b/pkg/java/src/test/java/dev/openfga/language/FgaModToJsonShould.java
@@ -1,0 +1,62 @@
+package dev.openfga.language;
+
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import dev.openfga.language.errors.ModFileValidationError;
+import dev.openfga.language.errors.ModFileValidationSingleError;
+import dev.openfga.language.util.TestsData;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FgaModToJsonShould {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fgaModTestCases")
+    public void transformFgaMod(
+            String name, String fgaMod, String json, boolean skip, List<ModFileValidationSingleError> expectedErrors)
+            throws Exception, ModFileValidationError {
+        Assumptions.assumeFalse(skip);
+
+        if (json != null) {
+            var generatedJson = FgaModTransformer.transform(fgaMod);
+
+            var expected = JSON.stringify(JSON.parse(json, FgaModFile.class));
+
+            assertThat(generatedJson).isEqualTo(expected);
+        } else {
+            var thrown = catchThrowable(() -> FgaModTransformer.transform(fgaMod));
+
+            assertThat(thrown).isInstanceOf(ModFileValidationError.class);
+
+            var errorsCount = expectedErrors.size();
+
+            var formattedErrors = expectedErrors.stream()
+                    .map(error -> String.format(
+                            "validation error at line=%d, column=%d: %s",
+                            error.getLine().getStart(), error.getColumn().getStart(), error.getMessage()))
+                    .collect(joining("\n\t* "));
+
+            var expectedMessage = String.format(
+                    "%d error%s occurred:\n\t* %s\n\n", errorsCount, errorsCount > 1 ? "s" : "", formattedErrors);
+
+            assertThat(thrown).hasMessage(expectedMessage);
+        }
+    }
+
+    private static Stream<Arguments> fgaModTestCases() {
+        return TestsData.FGA_MOD_TRANSFORM_TEST_CASES.stream()
+                .map(testCase -> arguments(
+                        testCase.getName(),
+                        testCase.getModFile(),
+                        testCase.getJson(),
+                        testCase.isSkip(),
+                        testCase.getExpectedErrors()));
+    }
+}

--- a/pkg/java/src/test/java/dev/openfga/language/util/FgaModTestCase.java
+++ b/pkg/java/src/test/java/dev/openfga/language/util/FgaModTestCase.java
@@ -1,0 +1,69 @@
+package dev.openfga.language.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.openfga.language.errors.ModFileValidationSingleError;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FgaModTestCase {
+    @JsonProperty("name")
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private String name;
+
+    @JsonProperty("modFile")
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private String modFile;
+
+    @JsonProperty("json")
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private String json;
+
+    @JsonProperty("skip")
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private boolean skip;
+
+    @JsonProperty("expected_errors")
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private List<ModFileValidationSingleError> expectedErrors = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getModFile() {
+        return modFile;
+    }
+
+    public void setDsl(String modFile) {
+        this.modFile = modFile;
+    }
+
+    public String getJson() {
+        return json;
+    }
+
+    public void setJson(String json) {
+        this.json = json;
+    }
+
+    public boolean isSkip() {
+        return skip;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
+    }
+
+    public List<ModFileValidationSingleError> getExpectedErrors() {
+        return expectedErrors;
+    }
+
+    public void setExpectedErrors(List<ModFileValidationSingleError> expectedErrors) {
+        this.expectedErrors = expectedErrors;
+    }
+}

--- a/pkg/java/src/test/java/dev/openfga/language/util/TestsData.java
+++ b/pkg/java/src/test/java/dev/openfga/language/util/TestsData.java
@@ -18,6 +18,7 @@ public class TestsData {
     public static final String DSL_SEMANTIC_CASES_FILE = "../../tests/data/dsl-semantic-validation-cases.yaml";
     public static final String JSON_SYNTAX_TRANSFORMER_CASES_FILE =
             "../../tests/data/json-syntax-transformer-validation-cases.yaml";
+    public static final String FGA_MOD_CASES_FILE = "../../tests/data/fga-mod-transformer-cases.yaml";
     public static final String SKIP_FILE = "test.skip";
     public static final String AUTHORIZATION_MODEL_JSON_FILE = "authorization-model.json";
     public static final String AUTHORIZATION_MODEL_DSL_FILE = "authorization-model.fga";
@@ -26,6 +27,7 @@ public class TestsData {
     public static final List<DslSyntaxTestCase> DSL_SYNTAX_TEST_CASES = loadDslSyntaxTestCases();
     public static final List<MultipleInvalidDslSyntaxTestCase> DSL_VALIDATION_TEST_CASES = loadDslValidationTestCases();
     public static final List<JsonSyntaxTestCase> JSON_SYNTAX_TEST_CASES = loadJsonSyntaxTestCases();
+    public static final List<FgaModTestCase> FGA_MOD_TRANSFORM_TEST_CASES = loadFgaModTransformTestCases();
 
     private static List<ValidTransformerTestCase> loadValidTransformerTestCases() {
         var transformerCasesFolder = Paths.get(TRANSFORMER_CASES_FOLDER);
@@ -77,6 +79,16 @@ public class TestsData {
         try {
             var json = Files.readString(dslSyntaxCasesFile);
             return YAML.parseList(json, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<FgaModTestCase> loadFgaModTransformTestCases() {
+        var fgaModCasesFile = Paths.get(FGA_MOD_CASES_FILE);
+        try {
+            var yaml = Files.readString(fgaModCasesFile);
+            return YAML.parseList(yaml, new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Description

Implements `fga.mod` transformation for the Java package, the yaml handling is done using the Jackson library that was already being used for tests. I evaluated some of the other libraries mentioned on the [yaml site](https://yaml.org) but they either proved too low level (snakeYAML) or didn't provide the functionality we needed (the rest).

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
