### PR TITLE
ci: remove feature branch and fix path on java pr target

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - feat/148-support-modular-models
     tags:
       - 'v*'
   merge_group:

--- a/.github/workflows/main-java.yml
+++ b/.github/workflows/main-java.yml
@@ -14,7 +14,7 @@ on:
       - 'pkg/java/**'
       - 'OpenFGAParser.g4'
       - 'OpenFGALexer.g4'
-      - tests/**'
+      - 'tests/**'
 
 permissions:
   contents: read

--- a/.github/workflows/main-js.yaml
+++ b/.github/workflows/main-js.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - feat/148-support-modular-models
     tags:
       - 'v*'
   merge_group:


### PR DESCRIPTION
## Description

I forgot to remove the CI setup for the modular models feature branch at merge, so remove that and also fix the `paths` value in the java workflow as it currently wont run if we edit the tests due to a missing quote

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
