### PR TITLE
chore: migrating server tests

### DIFF
--- a/pkg/java/src/main/java/dev/openfga/language/validation/ValidationErrorsBuilder.java
+++ b/pkg/java/src/main/java/dev/openfga/language/validation/ValidationErrorsBuilder.java
@@ -108,7 +108,11 @@ class ValidationErrorsBuilder {
 
     public void raiseInvalidType(int lineIndex, String symbol, String typeName) {
         var message = "`" + typeName + "` is not a valid type.";
-        var errorProperties = buildErrorProperties(message, lineIndex, symbol);
+        var errorProperties = buildErrorProperties(message, lineIndex, symbol, (wordIdx, rawLine, type) -> {
+            // Split line at definition as InvalidType should mark the value, not the key
+            var splitLine = rawLine.split(":");
+            return splitLine[0].length() + splitLine[1].indexOf(typeName) + 1;
+        });
         var metadata = new ValidationMetadata(symbol, ValidationError.InvalidType);
         errors.add(new ModelValidationSingleError(errorProperties, metadata));
     }

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -293,14 +293,20 @@ function resolveWordIndex(e: ModelValidationSingleError, line: string): number {
     return -1;
   }
 
+  const re = new RegExp("\\b" + metadata.symbol + "\\b");
+
   let wordIdx;
   switch (metadata.errorType) {
+    case ValidationError.InvalidType:
+      // Split line at definition as InvalidType should mark the value, not the key
+      const splitLine = line.split(":");
+      wordIdx = splitLine[0].length + splitLine[1].search(re) + 1;
+      break;
     case ValidationError.TuplesetNotDirect:
       const clauseStartsAt = line.indexOf("from") + "from".length;
       wordIdx = clauseStartsAt + line.slice(clauseStartsAt).indexOf(metadata.symbol);
       break;
     default:
-      const re = new RegExp("\\b" + metadata.symbol + "\\b");
       wordIdx = line?.search(re);
   }
 

--- a/pkg/js/util/exceptions.ts
+++ b/pkg/js/util/exceptions.ts
@@ -212,6 +212,12 @@ const createInvalidTypeError = (props: BaseProps, typeName: string) => {
       lines,
       lineIndex,
       metadata: { symbol, errorType: ValidationError.InvalidType, typeName: typeName, file, module, relation },
+      customResolver: (wordIndex: number, rawLine: string, symbol: string): number => {
+        // Split line at definition as InvalidType should mark the value, not the key
+        const re = new RegExp("\\b" + symbol + "\\b");
+        const splitLine = rawLine.split(":");
+        return splitLine[0].length + splitLine[1].search(re) + 1;
+      },
     }),
   );
 };

--- a/tests/data/dsl-semantic-validation-cases.yaml
+++ b/tests/data/dsl-semantic-validation-cases.yaml
@@ -1412,6 +1412,508 @@
         end: 29
       metadata:
         errorType: invalid-relation-type
+
+# Cycle tests
+
+- name: cycle 1 should fail
+  dsl: |
+    model
+      schema 1.1
+    type resource
+      relations
+        define x: y
+        define y: x
+  expected_errors:
+    - msg: "`x` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 4
+        end: 4
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`y` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: cycle 2 should fail
+  dsl: |
+    model
+      schema 1.1
+    type resource
+      relations
+        define x: y
+        define y: z
+        define z: x
+  expected_errors:
+    - msg: "`x` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 4
+        end: 4
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`y` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`z` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+
+# Cycles currnetly not being caught
+
+- name: cycle 3 should fail
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type resource
+      relations
+        define x: [user] or y
+        define y: [user] or z
+        define z: [user] or x
+  expected_errors:
+    - msg: "`x` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`y` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`z` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: cycle 4 should fail
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type resource
+      relations
+        define x: [user] but not y
+        define y: [user] but not z
+        define z: [user] or x
+  expected_errors:
+    - msg: "`x` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`y` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`z` is an impossible relation for `resource` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 12
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: cycle 5 should fail
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type group
+      relations
+        define member: [user] or memberA or memberB or memberC
+        define memberA: [user] or member or memberB or memberC
+        define memberB: [user] or member or memberA or memberC
+        define memberC: [user] or member or memberA or memberB
+  expected_errors:
+    - msg: "`member` is an impossible relation for `group` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 17
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`memberA` is an impossible relation for `group` (potential loop)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`memberB` is an impossible relation for `group` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`memberC` is an impossible relation for `group` (potential loop)."
+      line:
+        start: 8
+        end: 8
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: cycle 6 should fail
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type account
+      relations
+        define admin: [user] or member or super_admin or owner
+        define member: [user] or owner or admin or super_admin
+        define super_admin: [user] or admin or member or owner
+        define owner: [user]
+  expected_errors:
+    - msg: "`admin` is an impossible relation for `account` (potential loop)."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 11
+        end: 16
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`member` is an impossible relation for `account` (potential loop)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 17
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`super_admin` is an impossible relation for `account` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 22
+      metadata:
+        errorType: relation-no-entry-point
+
+# - name: cycle 7
+#   dsl: |
+#     model
+#       schema 1.1
+#     type user
+#     type document
+#       relations
+#         define editor: [user]
+#         define viewer: [document#viewer] or editor
+#   expected_errors: []
+
+# Validate
+
+- name: direct_relationship_with_entrypoint should pass
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define viewer: [user]
+  expected_errors: []
+
+- name: computed_relationship_with_entrypoint should pass
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define editor: [user]
+        define viewer: editor
+  expected_errors: []
+
+- name: no_entrypoint_1 should fail
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define admin: [user]
+        define action1: admin and action2 and action3
+        define action2: admin and action1 and action3
+        define action3: admin and action1 and action2
+  expected_errors:
+    - msg: "`action1` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`action2` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 8
+        end: 8
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`action3` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 9
+        end: 9
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: no_entrypoint_2 should fail
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define admin: [user]
+        define action1: admin but not action2
+        define action2: admin but not action3
+        define action3: admin but not action1
+  expected_errors:
+    - msg: "`action1` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 7
+        end: 7
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`action2` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 8
+        end: 8
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+    - msg: "`action3` is an impossible relation for `document` (potential loop)."
+      line:
+        start: 9
+        end: 9
+      column:
+        start: 11
+        end: 18
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: no_entrypoint_3a should fail
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define viewer: [document#viewer] and editor
+        define editor: [user]
+  expected_errors:
+    - msg: "`viewer` is an impossible relation for `document` (no entrypoint)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 17
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: no_entrypoint_3b should fail
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define viewer: [document#viewer] but not editor
+        define editor: [user]
+  expected_errors:
+    - msg: "`viewer` is an impossible relation for `document` (no entrypoint)."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 11
+        end: 17
+      metadata:
+        errorType: relation-no-entry-point
+
+- name: no_entrypoint_4 should fail
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type folder
+      relations
+        define parent: [document]
+        define viewer: editor from parent
+
+    type document
+      relations
+        define parent: [folder]
+        define editor: viewer
+        define viewer: editor from parent
+  expected_errors:
+    - msg: "the `editor` relation definition on type `document` is not valid: `editor` does not exist on `parent`, which is of type `folder`."
+      line:
+        start: 13
+        end: 13
+      column:
+        start: 19
+        end: 37
+      metadata:
+        errorType: invalid-relation-on-tupleset
+
+- name: self_referencing_type_restriction_with_entrypoint_1 should pass
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define restricted: [user]
+        define editor: [user]
+        define viewer: [document#viewer] or editor
+        define can_view: viewer but not restricted
+        define can_view_actual: can_view
+  expected_errors: []
+
+- name: self_referencing_type_restriction_with_entrypoint_2 should pass
+  dsl: |
+    model
+      schema 1.1
+    type user
+
+    type document
+      relations
+        define editor: [user]
+        define viewer: [document#viewer] or editor
+  expected_errors: []
+
+# Models with loops, but are valid because of an entry point
+
+- name: union does not require all child to have entry
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type doc
+      relations
+        define admin: [user]
+        define action1: admin or action2 or action3
+        define action2: admin or action3 or action1
+        define action3: admin or action1 or action2
+  expected_errors: []
+
+- name: union does not require all child to have entry even for intersection child
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type docs
+      relations
+        define admin: [user]
+        define union1: admin or union2
+        define union2: admin or union1
+        define intersection1: union1 and union2
+        define intersection2: union1 and union2
+  expected_errors: []
+
+- name: union does not require all child to have entry even for exclusion child
+  skip: true
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type docs
+      relations
+        define admin: [user]
+        define union1: admin or union2
+        define union2: admin or union1
+        define exclusion1: admin but not union1
+        define exclusion2: admin but not union2
+  expected_errors: []
+
 #- name: invalid cel expression
 #  dsl: |
 #    model
@@ -1451,3 +1953,34 @@
 #    }
 #  expected_errors:
 #    - msg: some error
+
+- name: invalid type error maps to wrong location when duplicate relation name is used in direct assignment
+  dsl: |
+    model
+      schema 1.1
+    type custome
+    type bank
+      relations
+        define customer : [customer]
+    type account
+      relations
+        define owner : [customer]
+  expected_errors:
+    - msg: "`customer` is not a valid type."
+      line:
+        start: 5
+        end: 5
+      column:
+        start: 23
+        end: 31
+      metadata:
+        errorType: invalid-type
+    - msg: "`customer` is not a valid type."
+      line:
+        start: 8
+        end: 8
+      column:
+        start: 20
+        end: 28
+      metadata:
+        errorType: invalid-type


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* Added tests from API
  * Cycle tests are currently skipped
* Fix `InvalidType` exception when type & relation name. `InvalidType` now only marks the type on the right side of a relation definition
* refactor `hasEntryPointOrLoop` to return objects, not arrays

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

* https://github.com/openfga/language/issues/181
* https://github.com/openfga/language/issues/259


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
