### PR TITLE
fix: java syntax errors have wrong line base

### DIFF
--- a/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
+++ b/pkg/java/src/main/java/dev/openfga/language/OpenFgaDslErrorListener.java
@@ -39,8 +39,8 @@ public class OpenFgaDslErrorListener implements ANTLRErrorListener {
             columnOffset = metadata.getSymbol().length();
         }
 
-        var properties =
-                new ErrorProperties(new StartEnd(line, line), new StartEnd(column, column + columnOffset), message);
+        var properties = new ErrorProperties(
+                new StartEnd(line - 1, line - 1), new StartEnd(column, column + columnOffset), message);
         this.errors.add(new SyntaxError(properties, metadata, e));
     }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This bug when uncaught because it is a wrapped ANTLR error and the line & col number are not compared as part of the tests.

https://github.com/openfga/language/blob/2663f80f254c099b7d588890587880da530b70e8/pkg/java/src/test/java/dev/openfga/language/ModelValidatorShould.java#L39

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- fixes https://github.com/openfga/language/issues/329

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
