### PR TITLE
feat: add method to get module for a relation & check if rel assignable

### DIFF
--- a/pkg/go/utils/model_utils.go
+++ b/pkg/go/utils/model_utils.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"fmt"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+)
+
+// GetModuleForObjectTypeRelation returns the module for the given object type and relation in that type.
+//
+// Parameters:
+// - typeDef: A pointer to an openfgav1.TypeDefinition object which contains metadata about the type.
+// - relation: A string representing the relation whose module is to be retrieved.
+//
+// Returns:
+// - A string representing the module for the given object type and relation.
+// - An error if the relation does not exist.
+func GetModuleForObjectTypeRelation(typeDef *openfgav1.TypeDefinition, relation string) (string, error) {
+	relations := typeDef.GetRelations()
+	_, exists := relations[relation]
+
+	if !exists {
+		return "", fmt.Errorf("relation %s does not exist in type %s", relation, typeDef.GetType()) //nolint:goerr113
+	}
+
+	relationsMetadata := typeDef.GetMetadata().GetRelations()
+	relationMetadata, exists := relationsMetadata[relation]
+	if !exists || relationMetadata.GetModule() == "" {
+		return typeDef.GetMetadata().GetModule(), nil
+	}
+
+	return relationMetadata.GetModule(), nil
+}
+
+// IsRelationAssignable returns true if the relation is assignable, as in the relation definition has a key "this" or
+// any of its children have a key "this".
+func IsRelationAssignable(relDef *openfgav1.Userset) bool { //nolint:cyclop
+	switch rel := relDef.GetUserset().(type) {
+	case *openfgav1.Userset_This:
+		return true
+	case *openfgav1.Userset_Union:
+		for _, child := range rel.Union.GetChild() {
+			if IsRelationAssignable(child) {
+				return true
+			}
+		}
+	case *openfgav1.Userset_Intersection:
+		for _, child := range rel.Intersection.GetChild() {
+			if IsRelationAssignable(child) {
+				return true
+			}
+		}
+	case *openfgav1.Userset_Difference:
+		if IsRelationAssignable(rel.Difference.GetBase()) || IsRelationAssignable(rel.Difference.GetSubtract()) {
+			return true
+		}
+	}
+
+	// ComputedUserset and TupleToUserset are not assignable
+	return false
+}

--- a/pkg/go/utils/model_utils_test.go
+++ b/pkg/go/utils/model_utils_test.go
@@ -1,0 +1,215 @@
+package utils
+
+import (
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+)
+
+func TestGetModuleForObjectTypeRelation(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		typeDef  *openfgav1.TypeDefinition
+		relation string
+	}
+
+	typeDefWithModule := &openfgav1.TypeDefinition{
+		Type: "type1",
+		Relations: map[string]*openfgav1.Userset{
+			"relation1": {},
+			"relation2": {},
+			"relation3": {},
+			"relation4": {},
+		},
+		Metadata: &openfgav1.Metadata{
+			Module: "type_module1",
+			Relations: map[string]*openfgav1.RelationMetadata{
+				"relation1": {Module: "module1"},
+				"relation2": {Module: ""},
+				"relation3": {},
+				"relation5": {},
+			},
+		},
+	}
+
+	typeDefWithoutModule := &openfgav1.TypeDefinition{
+		Type: "type2",
+		Relations: map[string]*openfgav1.Userset{
+			"relation7": {},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Relation exists and has a module",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation1",
+			},
+			want:    "module1",
+			wantErr: false,
+		},
+		{
+			name: "Relation exists but has an empty string as a module, type has a module",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation2",
+			},
+			want:    "type_module1",
+			wantErr: false,
+		},
+		{
+			name: "Relation exists but does not have a module, type has a module",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation3",
+			},
+			want:    "type_module1",
+			wantErr: false,
+		},
+		{
+			name: "Relation exists but does not have metadata, type has a module",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation4",
+			},
+			want:    "type_module1",
+			wantErr: false,
+		},
+		{
+			name: "Relation does not exist",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation5",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Relation does not exist 2",
+			args: args{
+				typeDef:  typeDefWithModule,
+				relation: "relation6",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Relation exists but does not have a module, type does not have a module",
+			args: args{
+				typeDef:  typeDefWithoutModule,
+				relation: "relation7",
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetModuleForObjectTypeRelation(tt.args.typeDef, tt.args.relation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetModuleForObjectTypeRelation() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("GetModuleForObjectTypeRelation() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRelationAssignable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		relDef   *openfgav1.Userset
+		expected bool
+	}{
+		{
+			name:     "Relation definition has a key 'this'",
+			relDef:   &openfgav1.Userset{Userset: &openfgav1.Userset_This{}},
+			expected: true,
+		},
+		{
+			name: "Relation definition has a key 'union' with a child that has a key 'this'",
+			relDef: &openfgav1.Userset{Userset: &openfgav1.Userset_Union{
+				Union: &openfgav1.Usersets{
+					Child: []*openfgav1.Userset{
+						{Userset: &openfgav1.Userset_This{}},
+					},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "Relation definition has a key 'intersection' with a child that has a key 'this'",
+			relDef: &openfgav1.Userset{Userset: &openfgav1.Userset_Intersection{
+				Intersection: &openfgav1.Usersets{
+					Child: []*openfgav1.Userset{
+						{Userset: &openfgav1.Userset_This{}},
+					},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "Relation definition has a key 'difference' with base having a key 'this'",
+			relDef: &openfgav1.Userset{Userset: &openfgav1.Userset_Difference{
+				Difference: &openfgav1.Difference{
+					Base:     &openfgav1.Userset{Userset: &openfgav1.Userset_This{}},
+					Subtract: &openfgav1.Userset{},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "Relation definition has a key 'difference' with subtract having a key 'this'",
+			relDef: &openfgav1.Userset{Userset: &openfgav1.Userset_Difference{
+				Difference: &openfgav1.Difference{
+					Base:     &openfgav1.Userset{},
+					Subtract: &openfgav1.Userset{Userset: &openfgav1.Userset_This{}},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: "Relation definition does not have any assignable keys",
+			relDef: &openfgav1.Userset{Userset: &openfgav1.Userset_Union{
+				Union: &openfgav1.Usersets{
+					Child: []*openfgav1.Userset{
+						{Userset: &openfgav1.Userset_Intersection{
+							Intersection: &openfgav1.Usersets{
+								Child: []*openfgav1.Userset{
+									{},
+								},
+							},
+						}},
+					},
+				},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := IsRelationAssignable(tt.relDef)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/java/src/main/java/dev/openfga/language/utils/ModelUtils.java
+++ b/pkg/java/src/main/java/dev/openfga/language/utils/ModelUtils.java
@@ -1,0 +1,75 @@
+package dev.openfga.language.utils;
+
+import dev.openfga.sdk.api.model.Metadata;
+import dev.openfga.sdk.api.model.RelationMetadata;
+import dev.openfga.sdk.api.model.TypeDefinition;
+import dev.openfga.sdk.api.model.Userset;
+import java.util.Map;
+
+public class ModelUtils {
+    /**
+     * getModuleForObjectTypeRelation returns the module for the given object type and relation in that type.
+     *
+     * @param typeDef  A TypeDefinition object which contains metadata about the type.
+     * @param relation A string representing the relation whose module is to be retrieved.
+     * @return A string representing the module for the given object type and relation.
+     * @throws Exception An error if the relation does not exist.
+     */
+    public static String getModuleForObjectTypeRelation(TypeDefinition typeDef, String relation) throws Exception {
+        Map<String, Userset> relations = typeDef.getRelations();
+        if (relations == null || !relations.containsKey(relation)) {
+            throw new Exception("relation " + relation + " does not exist in type " + typeDef.getType());
+        }
+
+        Metadata metadata = typeDef.getMetadata();
+        if (metadata == null || metadata.getRelations() == null) {
+            return null;
+        }
+
+        RelationMetadata relationMetadata = metadata.getRelations().get(relation);
+        if (relationMetadata == null
+                || relationMetadata.getModule() == null
+                || relationMetadata.getModule().isEmpty()) {
+            return metadata.getModule();
+        }
+
+        return relationMetadata.getModule();
+    }
+
+    /**
+     * isRelationAssignable returns true if the relation is assignable, as in the relation definition has a key "this" or
+     * any of its children have a key "this".
+     *
+     * @param relDef A Userset object representing a relation definition.
+     * @return A boolean representing whether the relation definition has a key "this".
+     */
+    public static boolean isRelationAssignable(Userset relDef) {
+        if (relDef == null) {
+            return false;
+        }
+
+        if (relDef.getThis() != null) {
+            return true;
+        } else if (relDef.getUnion() != null) {
+            for (Userset child : relDef.getUnion().getChild()) {
+                if (isRelationAssignable(child)) {
+                    return true;
+                }
+            }
+        } else if (relDef.getIntersection() != null) {
+            for (Userset child : relDef.getIntersection().getChild()) {
+                if (isRelationAssignable(child)) {
+                    return true;
+                }
+            }
+        } else if (relDef.getDifference() != null) {
+            var diff = relDef.getDifference();
+            if (isRelationAssignable(diff.getBase()) || isRelationAssignable(diff.getSubtract())) {
+                return true;
+            }
+        }
+
+        // ComputedUserset and TupleToUserset are not assignable
+        return false;
+    }
+}

--- a/pkg/java/src/test/java/dev/openfga/language/utils/ModelUtilsTest.java
+++ b/pkg/java/src/test/java/dev/openfga/language/utils/ModelUtilsTest.java
@@ -1,0 +1,160 @@
+// ModelUtilsTest.java
+package dev.openfga.language.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.openfga.sdk.api.model.*;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ModelUtilsTest {
+    private TypeDefinition getTypeDefWithModules() {
+        return new TypeDefinition()
+                .type("type1")
+                .relations(Map.of(
+                        "relation1", new Userset(),
+                        "relation2", new Userset(),
+                        "relation3", new Userset(),
+                        "relation4", new Userset()))
+                .metadata(new Metadata()
+                        .module("type_module1")
+                        .relations(Map.of(
+                                "relation1",
+                                new RelationMetadata().module("module1"),
+                                "relation2",
+                                new RelationMetadata().module(""),
+                                "relation3",
+                                new RelationMetadata(),
+                                "relation5",
+                                new RelationMetadata())));
+    }
+
+    private TypeDefinition getTypeDefWithoutModules() {
+        return new TypeDefinition().type("type2").relations(Map.of("relation7", new Userset()));
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationExistsAndHasModule() throws Exception {
+        String result = ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation1");
+        assertEquals("module1", result);
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationExistsButHasEmptyModule_TypeHasModule() throws Exception {
+        String result = ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation2");
+        assertEquals("type_module1", result);
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationExistsButNoModule_TypeHasModule() throws Exception {
+        String result = ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation3");
+        assertEquals("type_module1", result);
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationExistsButNoMetadata_TypeHasModule() throws Exception {
+        String result = ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation4");
+        assertEquals("type_module1", result);
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationDoesNotExist() {
+        Exception exception = assertThrows(Exception.class, () -> {
+            ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation5");
+        });
+
+        assertEquals("relation relation5 does not exist in type type1", exception.getMessage());
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationDoesNotExist2() {
+        Exception exception = assertThrows(Exception.class, () -> {
+            ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithModules(), "relation6");
+        });
+
+        assertEquals("relation relation6 does not exist in type type1", exception.getMessage());
+    }
+
+    @Test
+    public void testGetModuleForObjectTypeRelation_RelationExistsButNoModule_TypeNoModule() throws Exception {
+        String result = ModelUtils.getModuleForObjectTypeRelation(getTypeDefWithoutModules(), "relation7");
+        assertEquals(null, result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasThis() {
+        Userset relDef = new Userset();
+        relDef.setThis(new Object());
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasUnionWithThis() {
+        Userset relDef = new Userset();
+        Usersets union = new Usersets();
+        Userset innerRelDef = new Userset();
+        innerRelDef.setThis(new Object());
+        union.setChild(List.of(innerRelDef));
+        relDef.setUnion(union);
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasIntersectionWithThis() {
+        Userset relDef = new Userset();
+        Usersets intersection = new Usersets();
+        Userset innerRelDef = new Userset();
+        innerRelDef.setThis(new Object());
+        intersection.setChild(List.of(innerRelDef));
+        relDef.setIntersection(intersection);
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasDifferenceWithBaseThis() {
+        Userset relDef = new Userset();
+        Difference difference = new Difference();
+        Userset innerRelDef = new Userset();
+        innerRelDef.setThis(new Object());
+        difference.setBase(innerRelDef);
+        relDef.setDifference(difference);
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasDifferenceWithSubtractThis() {
+        Userset relDef = new Userset();
+        Difference difference = new Difference();
+        Userset innerRelDef = new Userset();
+        innerRelDef.setThis(new Object());
+        difference.setSubtract(innerRelDef);
+        relDef.setDifference(difference);
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsRelationAssignable_RelationHasNoAssignableKeys() {
+        Userset relDef = new Userset();
+        Usersets union = new Usersets();
+        Usersets intersection = new Usersets();
+        intersection.setChild(List.of(new Userset()));
+        Userset intersectionUserset = new Userset();
+        intersectionUserset.setIntersection(intersection);
+        union.setChild(List.of(intersectionUserset));
+        relDef.setUnion(union);
+
+        boolean result = ModelUtils.isRelationAssignable(relDef);
+        assertFalse(result);
+    }
+}

--- a/pkg/js/util/model_utils.test.ts
+++ b/pkg/js/util/model_utils.test.ts
@@ -1,0 +1,102 @@
+import { getModuleForObjectTypeRelation, isRelationAssignable } from "./model_utils";
+import { TypeDefinition, Userset, Usersets, Difference } from "@openfga/sdk";
+import { describe } from "@jest/globals";
+
+describe("model_utils", () => {
+  describe("getModuleForObjectTypeRelation", () => {
+    const typeDefWithModule: TypeDefinition = {
+      type: "type1",
+      relations: {
+        relation1: {},
+        relation2: {},
+        relation3: {},
+        relation4: {},
+      },
+      metadata: {
+        module: "type_module1",
+        relations: {
+          relation1: { module: "module1" },
+          relation2: { module: "" },
+          relation3: {},
+          relation5: {},
+        },
+      },
+    };
+
+    const typeDefWithoutModule: TypeDefinition = {
+      type: "type2",
+      relations: {
+        relation7: {},
+      },
+    };
+
+    test("Relation exists and has a module", () => {
+      const result = getModuleForObjectTypeRelation(typeDefWithModule, "relation1");
+      expect(result).toBe("module1");
+    });
+
+    test("Relation exists but has an empty string as a module, type has a module", () => {
+      const result = getModuleForObjectTypeRelation(typeDefWithModule, "relation2");
+      expect(result).toBe("type_module1");
+    });
+
+    test("Relation exists but does not have a module, type has a module", () => {
+      const result = getModuleForObjectTypeRelation(typeDefWithModule, "relation3");
+      expect(result).toBe("type_module1");
+    });
+
+    test("Relation exists but does not have metadata, type has a module", () => {
+      const result = getModuleForObjectTypeRelation(typeDefWithModule, "relation4");
+      expect(result).toBe("type_module1");
+    });
+
+    test("Relation does not exist", () => {
+      expect(() => {
+        getModuleForObjectTypeRelation(typeDefWithModule, "relation5");
+      }).toThrow("relation relation5 does not exist in type type1");
+    });
+
+    test("Relation does not exist 2", () => {
+      expect(() => {
+        getModuleForObjectTypeRelation(typeDefWithModule, "relation6");
+      }).toThrow("relation relation6 does not exist in type type1");
+    });
+
+    test("Relation exists but does not have a module, type does not have a module", () => {
+      const result = getModuleForObjectTypeRelation(typeDefWithoutModule, "relation7");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("isRelationAssignable", () => {
+    test("Relation definition has a key 'this'", () => {
+      const relDef: Userset = { this: {} };
+      expect(isRelationAssignable(relDef)).toBe(true);
+    });
+
+    test("Relation definition has a key 'union' with a child that has a key 'this'", () => {
+      const relDef: Userset = { union: { child: [{ this: {} }] } as Usersets };
+      expect(isRelationAssignable(relDef)).toBe(true);
+    });
+
+    test("Relation definition has a key 'intersection' with a child that has a key 'this'", () => {
+      const relDef: Userset = { intersection: { child: [{ this: {} }] } as Usersets };
+      expect(isRelationAssignable(relDef)).toBe(true);
+    });
+
+    test("Relation definition has a key 'difference' with base having a key 'this'", () => {
+      const relDef: Userset = { difference: { base: { this: {} }, subtract: {} } as Difference };
+      expect(isRelationAssignable(relDef)).toBe(true);
+    });
+
+    test("Relation definition has a key 'difference' with subtract having a key 'this'", () => {
+      const relDef: Userset = { difference: { base: {}, subtract: { this: {} } } as Difference };
+      expect(isRelationAssignable(relDef)).toBe(true);
+    });
+
+    test("Relation definition does not have any assignable keys", () => {
+      const relDef: Userset = { union: { child: [{ intersection: { child: [{}] } }] } as Usersets };
+      expect(isRelationAssignable(relDef)).toBe(false);
+    });
+  });
+});

--- a/pkg/js/util/model_utils.ts
+++ b/pkg/js/util/model_utils.ts
@@ -1,0 +1,54 @@
+import { Difference, TypeDefinition, Userset, Usersets } from "@openfga/sdk";
+
+/**
+ * getModuleForObjectTypeRelation - returns the module for the given object type and relation in that type.
+ * @param typeDef - A TypeDefinition object which contains metadata about the type.
+ * @param relation - A string representing the relation whose module is to be retrieved.
+ * @return string - A string representing the module for the given object type and relation.
+ * @error error - An error if the relation does not exist.
+ */
+export function getModuleForObjectTypeRelation(typeDef: TypeDefinition, relation: string): string | undefined {
+  if (!typeDef.relations?.[relation]) {
+    throw new Error(`relation ${relation} does not exist in type ${typeDef.type}`);
+  }
+
+  const relationsMetadata = typeDef?.metadata?.relations || {};
+  const relationMetadata = relationsMetadata[relation];
+
+  if (!relationMetadata || !relationMetadata.module) {
+    return typeDef?.metadata?.module || undefined;
+  }
+
+  return relationMetadata.module;
+}
+
+/**
+ * isRelationAssignable - returns true if the relation is assignable, as in the relation definition has a key "this" or any of its children have a key "this".
+ * @param relDef - A Userset object representing a relation definition.
+ * @return boolean - A boolean representing whether the relation definition has a key "this".
+ */
+export function isRelationAssignable(relDef: Userset): boolean {
+  for (const key of Object.keys(relDef)) {
+    const val = relDef[key as keyof Userset];
+    if (key === "this") {
+      return true;
+    }
+
+    if (key === "union" || key === "intersection") {
+      for (const item of (val as Usersets).child) {
+        if (isRelationAssignable(item)) {
+          return true;
+        }
+      }
+    }
+
+    if (key === "difference") {
+      if (isRelationAssignable((val as Difference).base) || isRelationAssignable((val as Difference).subtract)) {
+        return true;
+      }
+    }
+  }
+
+  // ComputedUserset and TupleToUserset are not assignable
+  return false;
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This adds two methods:
	* `GetModuleForObjectTypeRelation`: returns the module for a specific type / relation
	* `IsRelationAssignable`: returns whether a relation is assignable or not

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
