### PR TITLE
release: release new versions of go, js and java

### DIFF
--- a/pkg/go/CHANGELOG.md
+++ b/pkg/go/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
-## v0.2.0-beta.0
+## pkg/go/v0.2.0-beta.1
 
-### [pkg/go/v0.2.0-beta.0](https://github.com/openfga/language/tree/a3958b8187145f3a1f98f1d7334ba49411521cc8/pkg/go) (2024-06-12)
+### [v0.2.0-beta.1](https://github.com/openfga/language/compare/pkg/go/v0.2.0-beta.0...pkg/go/v0.2.0-beta.1) (2024-09-06)
+
+Added:
+- Add `GetModuleForObjectTypeRelation` utility method (#336)
+- Add `IsRelationAssignable` utility method (#336)
+- Add utility validators for tuple fields and condition names (#294)
+- Add an initial implementation of a model graph (#307,#308,#309,#310,#316,#317,#321,#322,#330)
+
+Note: this version does not include the validation logic that the JS and Java ports have. See issue: https://github.com/openfga/language/issues/99
+
+## pkg/go/v0.2.0-beta.0
+
+### [v0.2.0-beta.0](https://github.com/openfga/language/tree/a3958b8187145f3a1f98f1d7334ba49411521cc8/pkg/go) (2024-06-12)
 
 - Initial release
 

--- a/pkg/java/CHANGELOG.md
+++ b/pkg/java/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
+## pkg/java/v0.2.0-beta.2
+
+### [v0.2.0-beta.2](https://github.com/openfga/language/compare/pkg/java/v0.2.0-beta.1...pkg/java/v0.2.0-beta.2) (2024-09-06)
+
+Added:
+- Add `getModuleForObjectTypeRelation` utility method (#336)
+- Add `isRelationAssignable` utility method (#336)
+- Add utility validators for tuple fields and condition names (#294)
+
+- Fixed:
+- `tupleuserset-not-direct` is now prioritized above `no-entrypoint` error (#314)
+- correct based index for reported errors that was causing the wrong location to be highlighted (#331)
+
 ## pkg/java/v0.2.0-beta.1
 
-### [pkg/java/v0.2.0-beta.1](https://github.com/openfga/language/tree/7b8d22c70355fb7a0796b17d18eafaaa6360759b/pkg/java) (2024-06-13)
+### [v0.2.0-beta.1](https://github.com/openfga/language/tree/7b8d22c70355fb7a0796b17d18eafaaa6360759b/pkg/java) (2024-06-13)
 
 - Initial release

--- a/pkg/java/publish.gradle
+++ b/pkg/java/publish.gradle
@@ -7,7 +7,7 @@ publishing {
                 group = 'dev.openfga'
                 artifactId = 'openfga-language'
                 name = 'openfga-language'
-                version = 'v0.2.0-beta.1'
+                version = 'v0.2.0-beta.2'
                 description = 'OpenFGA Language package: transformers, validators and more'
                 url = 'https://openfga.dev'
                 licenses {

--- a/pkg/js/CHANGELOG.md
+++ b/pkg/js/CHANGELOG.md
@@ -1,17 +1,32 @@
 # Changelog
 
-## v0.2.0-beta.19
+## pkg/js/v0.2.0-beta.20
 
-### [pkg/js/v0.2.0-beta.19](https://github.com/openfga/language/compare/a3958b8187145f3a1f98f1d7334ba49411521cc8...b7ca69293497250f2ef6e6824eef391269d2944f) (2024-07-25)
+### [v0.2.0-beta.20](https://github.com/openfga/language/compare/pkg/js/v0.2.0-beta.19...pkg/js/v0.2.0-beta.20) (2024-09-06)
+
+Added:
+
+- Add `getModuleForObjectTypeRelation` utility method (#336)
+- Add `isRelationAssignable` utility method (#336)
+
+Fixed:
+
+- correct reported location of errors in some cases (#127)
+- `tupleuserset-not-direct` is now prioritized above `no-entrypoint` error (#314)
+- condition name is now correctly restrict to 50 characters (#320)
+
+## pkg/js/v0.2.0-beta.19
+
+### [v0.2.0-beta.19](https://github.com/openfga/language/compare/pkg/js/v0.2.0-beta.18...pkg/js/v0.2.0-beta.19) (2024-07-25)
 
 Added:
 
 - migrated validation code for store files (#286)
 - getModulesFromJSON: function to get modules from json (#287)
 
-## v0.2.0-beta.18
+## pkg/js/v0.2.0-beta.18
 
-### [pkg/js/v0.2.0-beta.18](https://github.com/openfga/language/compare/34a1a85f8307547cfd44d270472c317cc64962dd...6bf7c3e4910b7acc1ff80d8c66a8e1277e949fe6) (2024-06-12)
+### [v0.2.0-beta.18](https://github.com/openfga/language/compare/34a1a85f8307547cfd44d270472c317cc64962dd...6bf7c3e4910b7acc1ff80d8c66a8e1277e949fe6) (2024-06-12)
 
 Fixed:
 
@@ -21,7 +36,7 @@ Added:
 
 - Implement fga.mod transformer (#243)
 
-## v0.2.0-beta.17
+## pkg/js/v0.2.0-beta.17
 
 ### [v0.2.0-beta.17](https://github.com/openfga/language/compare/f45e80a9f169370f7cbeb5da9d147e5ff0e7305e...7b0b7f08393b13d8c53509447ff6e3847542eefc) (2024-04-12)
 

--- a/pkg/js/package-lock.json
+++ b/pkg/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openfga/syntax-transformer",
-  "version": "0.2.0-beta.19",
+  "version": "0.2.0-beta.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openfga/syntax-transformer",
-      "version": "0.2.0-beta.19",
+      "version": "0.2.0-beta.20",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/pkg/js/package.json
+++ b/pkg/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfga/syntax-transformer",
-  "version": "0.2.0-beta.19",
+  "version": "0.2.0-beta.20",
   "description": "",
   "license": "Apache-2.0",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* **Go**: `v0.2.0-beta.1`
	Added:
	- Add `getModuleForObjectTypeRelation` utility method (#336)
	- Add `isRelationAssignable` utility method (#336)
	- Add utility validators for tuple fields and condition names (#294)
	- Add an initial implementation of a model graph (#307,#308,#309,#310,#316,#317,#321,#322,#330)
* **JS**: `v0.2.0-beta.20`
	Added:
	- Add `getModuleForObjectTypeRelation` utility method (#336)
	- Add `isRelationAssignable` utility method (#336)
	
	Fixed:
	- correct reported location of errors in some cases (#127)
	- `tupleuserset-not-direct` is now prioritized above `no-entrypoint` error (#314)
	- condition name is now correctly restrict to 50 characters (#320)
* **Java**: `v0.2.0-beta.2`
	Added:
	- Add `getModuleForObjectTypeRelation` utility method (#336)
	- Add `isRelationAssignable` utility method (#336)
	- Add utility validators for tuple fields and condition names (#294)
	
	- Fixed:
	- `tupleuserset-not-direct` is now prioritized above `no-entrypoint` error (#314)
	- correct based index for reported errors that was causing the wrong location to be highlighted (#331)


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
