### PR TITLE
docs: fix headers for latest releases

### DIFF
--- a/pkg/go/CHANGELOG.md
+++ b/pkg/go/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## pkg/go/v0.2.0-beta.1
+## pkg/go/v0.2.0-beta.2
 
 ### [v0.2.0-beta.2](https://github.com/openfga/language/compare/pkg/go/v0.2.0-beta.1...pkg/go/v0.2.0-beta.2) (2024-09-09)
 

--- a/pkg/js/CHANGELOG.md
+++ b/pkg/js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## pkg/js/v0.2.0-beta.20
+## pkg/js/v0.2.0-beta.21
 
 ### [v0.2.0-beta.21](https://github.com/openfga/language/compare/pkg/js/v0.2.0-beta.20...pkg/js/v0.2.0-beta.21) (2024-09-09)
 


### PR DESCRIPTION
## Description

Didn't update when copy pasting the new version

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
