### PR TITLE
feat: add Reversed method to graph

### DIFF
--- a/pkg/go/graph/graph.go
+++ b/pkg/go/graph/graph.go
@@ -72,17 +72,14 @@ func (g *AuthorizationModelGraph) DOTAttributers() (encoding.Attributer, encodin
 }
 
 func (g *AuthorizationModelGraph) Attributes() []encoding.Attribute {
-	// https://graphviz.org/docs/attrs/rankdir/
+	rankdir := "BT" // bottom to top
 	if g.drawingDirection == DrawingDirectionCheck {
-		return []encoding.Attribute{{
-			Key:   "rankdir",
-			Value: "TB",
-		}}
+		rankdir = "TB" // top to bottom
 	}
 
 	return []encoding.Attribute{{
-		Key:   "rankdir",
-		Value: "BT",
+		Key:   "rankdir", // https://graphviz.org/docs/attrs/rankdir/
+		Value: rankdir,
 	}}
 }
 

--- a/pkg/go/graph/graph.go
+++ b/pkg/go/graph/graph.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"errors"
+	"fmt"
 
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/encoding/dot"
@@ -10,8 +11,56 @@ import (
 
 var ErrBuildingGraph = errors.New("cannot build graph")
 
+type DrawingDirection bool
+
+const (
+	DrawingDirectionListObjects DrawingDirection = true
+	DrawingDirectionCheck       DrawingDirection = false
+)
+
 type AuthorizationModelGraph struct {
 	*multi.DirectedGraph
+	drawingDirection DrawingDirection
+}
+
+// Reversed returns a full copy of the graph, but with the direction of the arrows flipped.
+func (g *AuthorizationModelGraph) Reversed() (*AuthorizationModelGraph, error) {
+	graphBuilder := &AuthorizationModelGraphBuilder{
+		multi.NewDirectedGraph(), map[string]int64{},
+	}
+
+	// Add all nodes as-is.
+	iterNodes := g.Nodes()
+	for iterNodes.Next() {
+		nextNode := iterNodes.Node()
+		graphBuilder.AddNode(nextNode)
+	}
+
+	// Add all edges as-is, but with their From and To flipped.
+	iterEdges := g.Edges()
+	for iterEdges.Next() {
+		nextEdge, ok := iterEdges.Edge().(multi.Edge)
+		if !ok {
+			return nil, fmt.Errorf("%w: could not cast to multi.Edge", ErrBuildingGraph)
+		}
+		// NOTE: because we use a multigraph, one edge can include multiple lines, so we need to add each line individually.
+		iterLines := nextEdge.Lines
+		for iterLines.Next() {
+			nextLine := iterLines.Line()
+			casted, ok := nextLine.(*AuthorizationModelEdge)
+			if !ok {
+				return nil, fmt.Errorf("%w: could not cast to AuthorizationModelEdge", ErrBuildingGraph)
+			}
+			graphBuilder.AddEdge(nextLine.To(), nextLine.From(), casted.edgeType, casted.conditionedOn)
+		}
+	}
+
+	multigraph, ok := graphBuilder.DirectedMultigraphBuilder.(*multi.DirectedGraph)
+	if ok {
+		return &AuthorizationModelGraph{multigraph, !g.drawingDirection}, nil
+	}
+
+	return nil, fmt.Errorf("%w: could not cast to directed graph", ErrBuildingGraph)
 }
 
 var _ dot.Attributers = (*AuthorizationModelGraph)(nil)
@@ -21,7 +70,14 @@ func (g *AuthorizationModelGraph) DOTAttributers() (encoding.Attributer, encodin
 }
 
 func (g *AuthorizationModelGraph) Attributes() []encoding.Attribute {
-	// https://graphviz.org/docs/attrs/rankdir/ - bottom to top
+	// https://graphviz.org/docs/attrs/rankdir/
+	if g.drawingDirection == DrawingDirectionCheck {
+		return []encoding.Attribute{{
+			Key:   "rankdir",
+			Value: "TB",
+		}}
+	}
+
 	return []encoding.Attribute{{
 		Key:   "rankdir",
 		Value: "BT",

--- a/pkg/go/graph/graph_builder.go
+++ b/pkg/go/graph/graph_builder.go
@@ -30,7 +30,7 @@ func NewAuthorizationModelGraph(model *openfgav1.AuthorizationModel) (*Authoriza
 		return nil, err
 	}
 
-	return &AuthorizationModelGraph{res}, nil
+	return &AuthorizationModelGraph{res, DrawingDirectionListObjects}, nil
 }
 
 func parseModel(model *openfgav1.AuthorizationModel) (*multi.DirectedGraph, error) {

--- a/pkg/go/graph/graph_builder_test.go
+++ b/pkg/go/graph/graph_builder_test.go
@@ -1036,6 +1036,18 @@ rankdir=BT
 
 			require.Empty(t, diff, "expected %s\ngot\n%s", testCase.expectedOutput, actualDOT)
 			require.Equal(t, testCase.cycleInformation, graph.GetCycles())
+
+			// assert that dot(reverse(reverse(graph)) == dot(graph)
+			reverseGraph1, err := graph.Reversed()
+			require.NoError(t, err)
+			reverseGraph2, err := reverseGraph1.Reversed()
+			require.NoError(t, err)
+			reversedDot := reverseGraph2.GetDOT()
+			reversedSorted := getSorted(reversedDot)
+
+			diff = cmp.Diff(expectedSorted, reversedSorted)
+
+			require.Empty(t, diff, "expected %s\ngot\n%s", testCase.expectedOutput, reversedDot)
 		})
 	}
 }
@@ -1100,6 +1112,18 @@ func TestGetDOTRepresentation_2(t *testing.T) {
 			diff := cmp.Diff(expectedSorted, actualSorted)
 
 			require.Empty(t, diff, "expected %s\ngot\n%s", test.expectedOutput, actualDOT)
+
+			// assert that dot(reverse(reverse(graph)) == dot(graph)
+			reverseGraph1, err := graph.Reversed()
+			require.NoError(t, err)
+			reverseGraph2, err := reverseGraph1.Reversed()
+			require.NoError(t, err)
+			reversedDot := reverseGraph2.GetDOT()
+			reversedSorted := getSorted(reversedDot)
+
+			diff = cmp.Diff(expectedSorted, reversedSorted)
+
+			require.Empty(t, diff, "expected %s\ngot\n%s", test.expectedOutput, reversedDot)
 		})
 	}
 }

--- a/pkg/go/graph/graph_test.go
+++ b/pkg/go/graph/graph_test.go
@@ -1,0 +1,87 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	language "github.com/openfga/language/pkg/go/transformer"
+)
+
+func TestReverseGraph(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]struct {
+		model          string
+		expectedOutput string // can visualize in https://dreampuf.github.io/GraphvizOnline
+	}{
+		`direct_assignment`: {
+			model: `
+				model
+					schema 1.1
+				type user
+				type company
+					relations
+						define member: [user]
+						define owner: [user]
+						define approved_member: member or owner
+				type group
+					relations
+						define approved_member: [user]
+				type license
+					relations
+						define active_member: approved_member from owner
+						define owner: [company, group]`,
+			expectedOutput: `digraph {
+graph [
+rankdir=TB
+];
+
+// Node definitions.
+0 [label=company];
+1 [label="company#approved_member"];
+2 [label=union];
+3 [label="company#member"];
+4 [label="company#owner"];
+5 [label=user];
+6 [label=group];
+7 [label="group#approved_member"];
+8 [label=license];
+9 [label="license#active_member"];
+10 [label="license#owner"];
+
+// Edge definitions.
+1 -> 2;
+2 -> 3;
+2 -> 4;
+3 -> 5 [label=direct];
+4 -> 5 [label=direct];
+7 -> 5 [label=direct];
+9 -> 1 [headlabel="(license#owner)"];
+9 -> 7 [headlabel="(license#owner)"];
+10 -> 0 [label=direct];
+10 -> 6 [label=direct];
+}`,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := language.MustTransformDSLToProto(testCase.model)
+			graph, err := NewAuthorizationModelGraph(model)
+			require.NoError(t, err)
+			require.Equal(t, DrawingDirectionListObjects, graph.drawingDirection)
+			reversedGraph, err := graph.Reversed()
+			require.NoError(t, err)
+			require.Equal(t, DrawingDirectionCheck, reversedGraph.drawingDirection)
+			actualDOT := reversedGraph.GetDOT()
+			actualSorted := getSorted(actualDOT)
+			expectedSorted := getSorted(testCase.expectedOutput)
+
+			diff := cmp.Diff(expectedSorted, actualSorted)
+
+			require.Empty(t, diff, "expected %s\ngot\n%s", testCase.expectedOutput, actualDOT)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add ability to visualize and represent graphs like this (the direction of a Check API request)

<img width="943" alt="image" src="https://github.com/user-attachments/assets/89b5948f-5a18-49fd-aba0-bbc50f9ebb1f">


in addition to this (the direction of a ListObjects API request)

<img width="792" alt="image" src="https://github.com/user-attachments/assets/cbede1a9-c4a1-443c-aa82-9f274db0ccda">
