### PR TITLE
change to return the actual nodes that have loop

### DIFF
--- a/pkg/go/graph/graph.go
+++ b/pkg/go/graph/graph.go
@@ -2,6 +2,11 @@ package graph
 
 import (
 	"errors"
+	"reflect"
+	"slices"
+	"sort"
+
+	"github.com/openfga/language/pkg/go/utils"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
@@ -41,14 +46,59 @@ func (g *AuthorizationModelGraph) GetDOT() string {
 	return string(dotRepresentation)
 }
 
+func sortAndRemoveDuplicateAndAlgebraic(orig [][]string) [][]string {
+	newSlices := make(utils.SlicesOfSlices, 0, len(orig))
+	for _, slice := range orig {
+		newSlice := make([]string, 0, len(slice))
+		for _, item := range slice {
+			if item != union && item != intersection && item != exclusion && !slices.Contains(newSlice, item) {
+				newSlice = append(newSlice, item)
+			}
+		}
+		sort.Strings(newSlice)
+		if !slicesOfSliceContains(newSlices, newSlice) {
+			newSlices = append(newSlices, newSlice)
+		}
+	}
+	// now, sort the slices according to size
+	sort.Sort(newSlices)
+
+	return newSlices
+}
+
 // CycleInformation encapsulates whether the graph has cycles.
 type CycleInformation struct {
-	// If hasCyclesAtCompileTime is true, we should block this model from ever being written.
+	// If hasCyclesAtCompileTime is non-empty, we should block this model from ever being written.
 	// This is because we are trying to perform a Check on it will cause a stack overflow no matter what the tuples are.
-	hasCyclesAtCompileTime bool
+	hasCyclesAtCompileTime [][]string
 
-	// If canHaveCyclesAtRuntime is true, there could exist tuples that introduce a cycle.
-	canHaveCyclesAtRuntime bool
+	// If canHaveCyclesAtRuntime is non-empty, there could exist tuples that introduce a cycle.
+	canHaveCyclesAtRuntime [][]string
+}
+
+// slicesOfSliceContains returns true if the newSlice is deeply equal to any of the origSlices.
+func slicesOfSliceContains(origSlices [][]string, newSlice []string) bool {
+	for _, origSlice := range origSlices {
+		if reflect.DeepEqual(newSlice, origSlice) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SortedHasCyclesAtCompileTime returns a sorted HasCyclesAtCompileTime which removed algebraic operation (such as union/intersection/exclusion)
+// The []string are sorted by length. If []string has the same length, it will return if the first/second/third/.. item is smallest
+// Within each []string, it is sorted by alphabet.  In addition, the duplicate node is removed.
+func (c *CycleInformation) SortedHasCyclesAtCompileTime() [][]string {
+	return sortAndRemoveDuplicateAndAlgebraic(c.hasCyclesAtCompileTime)
+}
+
+// SortedCanHaveCyclesAtRuntime returns a sorted HasCyclesAtCompileTime which removed algebraic operation (such as union/intersection/exclusion)
+// The []string are sorted by length. If []string has the same length, it will return if the first/second/third/.. item is smallest
+// Within each []string, it is sorted by alphabet.  In addition, the duplicate node is removed.
+func (c *CycleInformation) SortedCanHaveCyclesAtRuntime() [][]string {
+	return sortAndRemoveDuplicateAndAlgebraic(c.canHaveCyclesAtRuntime)
 }
 
 func (g *AuthorizationModelGraph) nodeListHasNonComputedEdge(nodeList []graph.Node) bool {
@@ -67,24 +117,36 @@ func (g *AuthorizationModelGraph) nodeListHasNonComputedEdge(nodeList []graph.No
 	return false
 }
 
+func nodeListIdentifier(nodeList []graph.Node) []string {
+	labels := make([]string, 0, len(nodeList))
+	for _, node := range nodeList {
+		auth, ok := node.(*AuthorizationModelNode)
+		if ok {
+			labels = append(labels, auth.label)
+		}
+	}
+
+	return labels
+}
+
 func (g *AuthorizationModelGraph) GetCycles() CycleInformation {
-	hasCyclesAtCompileTime := false
-	hasCyclesAtRuntime := false
+	var nodesWithCyclesAtCompileTime [][]string
+	var nodesWithCyclesAtRuntime [][]string
 
 	// TODO: investigate whether len(1) should be identified as cycle
 
 	nodes := topo.DirectedCyclesIn(g)
 	for _, nodeList := range nodes {
 		if g.nodeListHasNonComputedEdge(nodeList) {
-			hasCyclesAtRuntime = true
+			nodesWithCyclesAtRuntime = append(nodesWithCyclesAtRuntime, nodeListIdentifier(nodeList))
 		} else {
-			hasCyclesAtCompileTime = true
+			nodesWithCyclesAtCompileTime = append(nodesWithCyclesAtCompileTime, nodeListIdentifier(nodeList))
 		}
 	}
 
 	return CycleInformation{
-		hasCyclesAtCompileTime: hasCyclesAtCompileTime,
-		canHaveCyclesAtRuntime: hasCyclesAtRuntime,
+		hasCyclesAtCompileTime: nodesWithCyclesAtCompileTime,
+		canHaveCyclesAtRuntime: nodesWithCyclesAtRuntime,
 	}
 }
 

--- a/pkg/go/graph/graph_builder.go
+++ b/pkg/go/graph/graph_builder.go
@@ -11,6 +11,12 @@ import (
 	"gonum.org/v1/gonum/graph/multi"
 )
 
+const (
+	union        = "union"
+	intersection = "intersection"
+	exclusion    = "exclusion"
+)
+
 type AuthorizationModelGraphBuilder struct {
 	graph.DirectedMultigraphBuilder
 
@@ -92,15 +98,15 @@ func checkRewrite(graphBuilder *AuthorizationModelGraphBuilder, parentNode *Auth
 
 		return
 	case *openfgav1.Userset_Union:
-		operator = "union"
+		operator = union
 		children = rw.Union.GetChild()
 
 	case *openfgav1.Userset_Intersection:
-		operator = "intersection"
+		operator = intersection
 		children = rw.Intersection.GetChild()
 
 	case *openfgav1.Userset_Difference:
-		operator = "exclusion"
+		operator = exclusion
 		children = []*openfgav1.Userset{
 			rw.Difference.GetBase(),
 			rw.Difference.GetSubtract(),

--- a/pkg/go/utils/slices_of_slices.go
+++ b/pkg/go/utils/slices_of_slices.go
@@ -1,0 +1,29 @@
+package utils
+
+type SlicesOfSlices [][]string
+
+func (s SlicesOfSlices) Len() int { return len(s) }
+
+func (s SlicesOfSlices) Less(i, j int) bool {
+	if len(s[i]) < len(s[j]) {
+		return true
+	}
+	if len(s[i]) > len(s[j]) {
+		return false
+	}
+	// the length is equal, sort according to item(from first to last)
+	for k := range s[i] {
+		if s[i][k] < s[j][k] {
+			return true
+		}
+		if s[i][k] > s[j][k] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s SlicesOfSlices) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/go/utils/slices_of_slices_test.go
+++ b/pkg/go/utils/slices_of_slices_test.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSlicesOfSlices_Less(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input SlicesOfSlices
+		want  bool
+	}{
+		{
+			name: "first_slice_longer",
+			input: SlicesOfSlices{
+				{"a", "b"},
+				{},
+			},
+			want: false,
+		},
+		{
+			name: "second_slice_longer",
+			input: SlicesOfSlices{
+				{},
+				{"a", "b"},
+			},
+			want: true,
+		},
+		{
+			name: "equal_length_first_slice_smaller_element",
+			input: SlicesOfSlices{
+				{"a", "b"},
+				{"x", "b"},
+			},
+			want: true,
+		},
+		{
+			name: "equal_length_first_slice_larger_element",
+			input: SlicesOfSlices{
+				{"x", "b"},
+				{"a", "b"},
+			},
+			want: false,
+		},
+		{
+			name: "equal_length_first_slice_smaller_last_element",
+			input: SlicesOfSlices{
+				{"a", "b"},
+				{"a", "c"},
+			},
+			want: true,
+		},
+		{
+			name: "equal_length_second_slice_smaller_last_element",
+			input: SlicesOfSlices{
+				{"a", "c"},
+				{"a", "b"},
+			},
+			want: false,
+		},
+		{
+			name: "equal_everything",
+			input: SlicesOfSlices{
+				{"a", "b"},
+				{"a", "b"},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output := tt.input.Less(0, 1)
+			require.Equal(t, tt.want, output)
+		})
+	}
+}


### PR DESCRIPTION

## Description
Update node detection to return list of nodes that have loop.  This allows caller to return the proper error message.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
