### PR TITLE
chore: return label and nodetype for AuthorizationModelNode

### DIFF
--- a/pkg/go/graph/graph_node.go
+++ b/pkg/go/graph/graph_node.go
@@ -34,3 +34,11 @@ func (n *AuthorizationModelNode) Attributes() []encoding.Attribute {
 
 	return attrs
 }
+
+func (n *AuthorizationModelNode) Label() string {
+	return n.label
+}
+
+func (n *AuthorizationModelNode) NodeType() NodeType {
+	return n.nodeType
+}


### PR DESCRIPTION

## Description
Allow AuthorizationModelNode to return Label and NodeType so that it be used as a library.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
