### PR TITLE
chore: introduce constant for operators

### DIFF
--- a/pkg/go/graph/graph_builder.go
+++ b/pkg/go/graph/graph_builder.go
@@ -91,15 +91,15 @@ func checkRewrite(graphBuilder *AuthorizationModelGraphBuilder, parentNode *Auth
 
 		return
 	case *openfgav1.Userset_Union:
-		operator = "union"
+		operator = UnionOperator
 		children = rw.Union.GetChild()
 
 	case *openfgav1.Userset_Intersection:
-		operator = "intersection"
+		operator = IntersectionOperator
 		children = rw.Intersection.GetChild()
 
 	case *openfgav1.Userset_Difference:
-		operator = "exclusion"
+		operator = ExclusionOperator
 		children = []*openfgav1.Userset{
 			rw.Difference.GetBase(),
 			rw.Difference.GetSubtract(),

--- a/pkg/go/graph/graph_node.go
+++ b/pkg/go/graph/graph_node.go
@@ -12,13 +12,16 @@ const (
 	SpecificTypeAndRelation NodeType = 1 // e.g. `group#viewer`
 	OperatorNode            NodeType = 2 // e.g. union
 	SpecificTypeWildcard    NodeType = 3 // e.g. `group:*`
+
+	UnionOperator        = "union"
+	IntersectionOperator = "intersection"
+	ExclusionOperator    = "exclusion"
 )
 
 type AuthorizationModelNode struct {
 	graph.Node
 
-	// custom attributes
-	label       string // e.g. `union`, for DOT
+	label       string // e.g. "group#member", UnionOperator, IntersectionOperator, ExclusionOperator
 	nodeType    NodeType
 	uniqueLabel string // e.g. `union:01J54ND7WHGAAJTGDMFWP4FZTR`
 }

--- a/pkg/go/graph/graph_test.go
+++ b/pkg/go/graph/graph_test.go
@@ -218,11 +218,11 @@ func TestGetNodeTypes(t *testing.T) {
 		}
 
 		switch node.label {
-		case "union":
+		case UnionOperator:
 			unionNodes = append(unionNodes, node)
-		case "intersection":
+		case IntersectionOperator:
 			intersectionNodes = append(intersectionNodes, node)
-		case "exclusion":
+		case ExclusionOperator:
 			differenceNodes = append(differenceNodes, node)
 		}
 	}


### PR DESCRIPTION
## Description

Address linter complaint: https://github.com/openfga/language/actions/runs/11024544895/job/30617891293?pr=351#step:5:871

```
Error: graph/graph_builder.go:94:14: string `union` has 3 occurrences, make it a constant (goconst)
		operator = "union"
		           ^
make[1]: *** [Makefile:41: lint] Error 1
make[1]: Leaving directory '/home/runner/work/language/language
```