### PR TITLE
fix: resolve crash in `TransformModuleFilesToModel` if regular schema file passed instead

### DIFF
--- a/pkg/go/transformer/module-to-model.go
+++ b/pkg/go/transformer/module-to-model.go
@@ -116,8 +116,15 @@ func TransformModuleFilesToModel( //nolint:funlen,gocognit,cyclop
 			}
 
 			types = append(types, typeDef.GetType())
-			typeDef.Metadata.SourceInfo = &openfgav1.SourceInfo{
-				File: module.Name,
+			if typeDef.Metadata != nil {
+				typeDef.Metadata.SourceInfo = &openfgav1.SourceInfo{
+					File: module.Name,
+				}
+			} else {
+				transformErrors = multierror.Append(transformErrors, &ModuleTransformationSingleError{
+					Msg: "file is not a module",
+				})
+				continue
 			}
 			rawTypeDefs = append(rawTypeDefs, typeDef)
 		}

--- a/pkg/js/transformer/modules/modules-to-model.ts
+++ b/pkg/js/transformer/modules/modules-to-model.ts
@@ -49,7 +49,17 @@ export const transformModuleFilesToModel = (
           extendedTypeDefs[name].push(typeDef);
           continue;
         }
-
+        if (!typeDef.metadata) {
+          errors.push(
+            new ModuleTransformationSingleError({
+              msg: "file is not a module",
+              line: { start: 0, end: 0 },
+              column: { start: 0, end: 0 },
+              file: "nomodule.fga",
+            }),
+          );
+          continue;
+        }
         typeDef.metadata!.source_info = {
           file: name,
         };

--- a/tests/data/transformer-module/01-module-with-errors/expected_errors.json
+++ b/tests/data/transformer-module/01-module-with-errors/expected_errors.json
@@ -1,5 +1,9 @@
 [
   {
+    "msg": "file is not a module",
+    "file":"nomodule.fga"
+  },
+  {
     "msg": "duplicate condition a_check",
     "file": "org.fga",
     "line": {

--- a/tests/data/transformer-module/01-module-with-errors/expected_errors.json
+++ b/tests/data/transformer-module/01-module-with-errors/expected_errors.json
@@ -1,7 +1,15 @@
 [
   {
     "msg": "file is not a module",
-    "file":"nomodule.fga"
+    "file":"nomodule.fga",
+    "line": {
+      "start": 0,
+      "end": 0
+    },
+    "column": {
+      "start": 0,
+      "end": 0
+    }
   },
   {
     "msg": "duplicate condition a_check",

--- a/tests/data/transformer-module/01-module-with-errors/module/nomodule.fga
+++ b/tests/data/transformer-module/01-module-with-errors/module/nomodule.fga
@@ -1,0 +1,4 @@
+model
+  schema 1.1
+
+type usernomodule


### PR DESCRIPTION


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The change checks the metadata for the module, if it's null it returns the proper error.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Fixes https://github.com/openfga/language/issues/384

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

