### PR TITLE
fix: exclusion weight where type is not in the excluded relation

### DIFF
--- a/pkg/go/graph/weighted_graph_test.go
+++ b/pkg/go/graph/weighted_graph_test.go
@@ -511,7 +511,7 @@ type company
 	  define approved_member: [user, company#member]
 	  define can_execute: executive but not approved_member
 */
-func TestInvalidWeight2ButNotMistmatchType(t *testing.T) {
+func TestWeight2ButNotMistmatchType(t *testing.T) {
 	t.Parallel()
 	graph := NewWeightedAuthorizationModelGraph()
 	graph.AddNode("company-member", "member", SpecificTypeAndRelation)
@@ -531,8 +531,13 @@ func TestInvalidWeight2ButNotMistmatchType(t *testing.T) {
 	graph.AddEdge("company-can_execute-but", "company-approved_member", ComputedEdge, "", nil)
 
 	err := graph.AssignWeights()
-	require.ErrorIs(t, err, ErrInvalidModel)
-	require.True(t, strings.HasPrefix(err.Error(), "invalid model: not all paths return the same type for the node"))
+	require.NoError(t, err)
+	require.Equal(t, 1, graph.nodes["company-member"].weights["user"])
+	require.Equal(t, 1, graph.nodes["company-executive"].weights["employee"])
+	require.Equal(t, 2, graph.nodes["company-approved_member"].weights["user"])
+	require.Equal(t, 1, graph.nodes["company-can_execute"].weights["employee"])
+	_, found := graph.nodes["company-can_execute"].weights["user"]
+	require.False(t, found)
 }
 
 /*


### PR DESCRIPTION
## Description
For relation A but not B, we need to use a mixed strategy in calculating weight where a type in A will use the max strategy and B will use the enforced type strategy. This is because a type can be connected to the graph if it appears only in A as B is not mandatory.  However, a type listed in B MUST also appear in A.  Otherwise, relation will never exist for such type.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

