### PR TITLE
ci(js): only run tests per node version

### DIFF
--- a/.github/workflows/pkg-js-build.yaml
+++ b/.github/workflows/pkg-js-build.yaml
@@ -63,5 +63,5 @@ jobs:
           cache-dependency-path: ./pkg/js/package-lock.json  
     
       - name: Build
-        run: make all-tests-js
+        run: make test-js
     


### PR DESCRIPTION
## Description

Aligns the JS workflow with Go/Java to only run `make test-js`, this is so that don't run any linting which reduces the chance of hitting errors with supporting older node versions (like in https://github.com/openfga/language/pull/462)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

