### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-js-release.yaml
+++ b/.github/workflows/pkg-js-release.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/pkg-js-build.yaml
     secrets: inherit
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/9](https://github.com/openfga/language/security/code-scanning/9)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/pkg-js-release.yaml`. The minimal and safest starting point is to set `permissions: {}` (no permissions), unless the reusable workflow requires specific permissions. If the reusable workflow only needs read access to the repository contents (which is common for test/build jobs), set `permissions: contents: read`. This change should be made directly under the `test:` job definition, before `uses:`. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
