### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-js-pr.yaml
+++ b/.github/workflows/pkg-js-pr.yaml
@@ -1,4 +1,6 @@
 name: PR (JS)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/8](https://github.com/openfga/language/security/code-scanning/8)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/pkg-js-pr.yaml`. This block can be added at the root level (applies to all jobs unless overridden) or at the job level. Since the workflow only delegates to a single job that uses a reusable workflow, the best practice is to add the `permissions` block at the root level, specifying the minimal permissions required. If you are unsure what permissions are needed, start with `contents: read`, which is the most restrictive and safest default. If the workflow requires additional permissions (e.g., to create or update pull requests), you can add them as needed. For now, add the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

This change should be made at the top of `.github/workflows/pkg-js-pr.yaml`, after the `name` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
