### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-java-release.yaml
+++ b/.github/workflows/pkg-java-release.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    permissions: {}
     uses: ./.github/workflows/pkg-java-build.yaml
     secrets: inherit
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/7](https://github.com/openfga/language/security/code-scanning/7)

To fix the problem, add an explicit `permissions` block to the `test` job in `.github/workflows/pkg-java-release.yaml`. If the job does not require any permissions (which is common for test jobs that do not interact with the repository or GitHub APIs), set `permissions: {}` to grant no permissions. If minimal read access is required, use `permissions: contents: read`. This change should be made directly under the `test:` job definition, before any other keys (such as `uses` or `secrets`). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
