### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-java-pr.yaml
+++ b/.github/workflows/pkg-java-pr.yaml
@@ -1,4 +1,6 @@
 name: PR (Java)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/6](https://github.com/openfga/language/security/code-scanning/6)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/pkg-java-pr.yaml`. This block should be placed at the top level (applies to all jobs unless overridden), or at the job level if different jobs require different permissions. Since the job here is simply calling a reusable workflow and there is no evidence of needing write access, we should set the permissions to the minimal required, typically `contents: read`. If the workflow needs to create or update pull requests, we can add `pull-requests: write`. However, as a minimal starting point, we will set `contents: read` at the workflow level, which is the recommended default.

Edit `.github/workflows/pkg-java-pr.yaml` to add the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
