### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -1,4 +1,6 @@
 name: Test (Go)
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/5](https://github.com/openfga/language/security/code-scanning/5)

To fix the problem, add a `permissions` block to the root of the workflow file (`.github/workflows/pkg-go-build.yaml`). This block should specify the minimal permissions required for the jobs in the workflow. Since all jobs only need to read repository contents (for checkout and diff), the minimal required permission is `contents: read`. Add the following block immediately after the `name:` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed. This change will ensure that the workflow only has read access to repository contents, reducing the risk of privilege escalation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
