### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -1,5 +1,8 @@
 name: Test (Go)
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/4](https://github.com/openfga/language/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` key at the top level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. Since the jobs in this workflow only check out code, set up Go, lint, audit, and build/test, the minimal required permission is `contents: read`. This ensures the workflow adheres to the principle of least privilege and prevents the `GITHUB_TOKEN` from having unnecessary write access. The change should be made by adding the following block after the `name:` and before the `on:` key in `.github/workflows/pkg-go-build.yaml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
