### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-go-pr.yaml
+++ b/.github/workflows/pkg-go-pr.yaml
@@ -1,5 +1,8 @@
 name: PR (Go)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/3](https://github.com/openfga/language/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the root level of the workflow, so it applies to all jobs unless overridden. Since the workflow appears to only run tests (by calling another workflow), it likely only needs read access to repository contents. Therefore, set `permissions: contents: read` at the top level of the workflow. This change should be made near the top of `.github/workflows/pkg-go-pr.yaml`, after the `name` field and before the `on` block, or immediately after the `on` block. No other code or functionality needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
