### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-go-release.yaml
+++ b/.github/workflows/pkg-go-release.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/pkg-go-build.yaml
     secrets: inherit
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/2](https://github.com/openfga/language/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/pkg-go-release.yaml`. The minimal and safest default is `contents: read`, which allows the job to read repository contents but not write or perform other privileged actions. This should be added at the same indentation level as `uses` and `secrets` under the `test` job. No other changes are needed, and this does not affect existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
