### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -1,5 +1,8 @@
 name: Test (Go)
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/language/security/code-scanning/1](https://github.com/openfga/language/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the jobs in this workflow only need to check out code and run local commands (lint, build, audit), the minimal required permission is `contents: read`. This can be set at the top level of the workflow file, which will apply to all jobs unless overridden. No changes to the jobs themselves are needed.

**Steps:**
- Add the following block after the `name:` line and before the `on:` block in `.github/workflows/pkg-go-build.yaml`:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
