### PR TITLE
Feat/grouping userset ttus

### DIFF
--- a/pkg/go/graph/graph_edge.go
+++ b/pkg/go/graph/graph_edge.go
@@ -8,10 +8,12 @@ import (
 type EdgeType int64
 
 const (
-	DirectEdge   EdgeType = 0
-	RewriteEdge  EdgeType = 1
-	TTUEdge      EdgeType = 2
-	ComputedEdge EdgeType = 3
+	DirectEdge        EdgeType = 0
+	RewriteEdge       EdgeType = 1
+	TTUEdge           EdgeType = 2
+	ComputedEdge      EdgeType = 3
+	DirectLogicalEdge EdgeType = 4
+	TTULogicalEdge    EdgeType = 5
 	// When an edge does not have cond in the model, it will have a condition with value none.
 	// This is required to differentiate when an edge need to support condition and no condition
 	// like define rel1: [user, user with condX], in this case the edge will have [none, condX]

--- a/pkg/go/graph/graph_edge.go
+++ b/pkg/go/graph/graph_edge.go
@@ -5,23 +5,6 @@ import (
 	"gonum.org/v1/gonum/graph/encoding"
 )
 
-type EdgeType int64
-
-const (
-	DirectEdge        EdgeType = 0
-	RewriteEdge       EdgeType = 1
-	TTUEdge           EdgeType = 2
-	ComputedEdge      EdgeType = 3
-	DirectLogicalEdge EdgeType = 4
-	TTULogicalEdge    EdgeType = 5
-	// When an edge does not have cond in the model, it will have a condition with value none.
-	// This is required to differentiate when an edge need to support condition and no condition
-	// like define rel1: [user, user with condX], in this case the edge will have [none, condX]
-	// or an edge needs to support only condition like define rel1: [user with condX], the edge will have [condX]
-	// in the case the edge does not have any condition like define rel1: [user], the edge will have [none].
-	NoCond string = "none"
-)
-
 type AuthorizationModelEdge struct {
 	graph.Line
 

--- a/pkg/go/graph/graph_node.go
+++ b/pkg/go/graph/graph_node.go
@@ -5,21 +5,6 @@ import (
 	"gonum.org/v1/gonum/graph/encoding"
 )
 
-type NodeType int64
-
-const (
-	SpecificType            NodeType = 0 // e.g. `group`
-	SpecificTypeAndRelation NodeType = 1 // e.g. `group#viewer`
-	OperatorNode            NodeType = 2 // e.g. union
-	SpecificTypeWildcard    NodeType = 3 // e.g. `group:*`
-	LogicalUserset          NodeType = 4 // e.g. `[user, employee, type1#rel]`
-	LogicalTTU              NodeType = 5 // e.g. `member from parent, wherer parent can have multiple terminal types`
-
-	UnionOperator        = "union"
-	IntersectionOperator = "intersection"
-	ExclusionOperator    = "exclusion"
-)
-
 type AuthorizationModelNode struct {
 	graph.Node
 

--- a/pkg/go/graph/graph_node.go
+++ b/pkg/go/graph/graph_node.go
@@ -12,6 +12,8 @@ const (
 	SpecificTypeAndRelation NodeType = 1 // e.g. `group#viewer`
 	OperatorNode            NodeType = 2 // e.g. union
 	SpecificTypeWildcard    NodeType = 3 // e.g. `group:*`
+	LogicalUserset          NodeType = 4 // e.g. `[user, employee, type1#rel]`
+	LogicalTTU              NodeType = 5 // e.g. `member from parent, wherer parent can have multiple terminal types`
 
 	UnionOperator        = "union"
 	IntersectionOperator = "intersection"

--- a/pkg/go/graph/weighted_graph.go
+++ b/pkg/go/graph/weighted_graph.go
@@ -129,8 +129,8 @@ func (wg *WeightedAuthorizationModelGraph) AssignWeights() error {
 	tupleCycleDependencies := make(map[string][]*WeightedAuthorizationModelEdge)
 
 	for nodeID, node := range wg.nodes {
-		if node.GetNodeType() == OperatorNode {
-			// Inititally defer weight assignment of operator nodes to later in `fixDependantNodesWeight()`.
+		if wg.isLogicalOperator(node) {
+			// Inititally defer weight assignment of operator nodes and the logical nodes to later in `fixDependantNodesWeight()`.
 			// This enables more deterministic behavior of intermediate functions.
 			continue
 		}
@@ -148,6 +148,22 @@ func (wg *WeightedAuthorizationModelGraph) AssignWeights() error {
 		}
 	}
 	return nil
+}
+
+func (wg *WeightedAuthorizationModelGraph) isLogicalOperator(node *WeightedAuthorizationModelNode) bool {
+	// a logical ttu is when a ttu has more than one edges due to having multiple terminal types as usersets,
+	// and should always be treated as a union among all those ttu edges as they belong to the same logical ttu
+	// a logical userset is when we have multiple asignations to terminal types or usersets, we need to treat that
+	// as a union for all the direct edges
+	return node.GetNodeType() == OperatorNode || node.GetNodeType() == LogicalTTU || node.GetNodeType() == LogicalUserset
+}
+
+func (wg *WeightedAuthorizationModelGraph) isLogicalUnionOperator(node *WeightedAuthorizationModelNode) bool {
+	// a logical ttu is when a ttu has more than one edges due to having multiple terminal types as usersets,
+	// and should always be treated as a union among all those ttu edges as they belong to the same logical ttu
+	// a logical userset is when we have multiple asignations to terminal types or usersets, we need to treat that
+	// as a union for all the direct edges
+	return (node.GetNodeType() == OperatorNode && node.GetLabel() == UnionOperator) || node.GetNodeType() == LogicalTTU || node.GetNodeType() == LogicalUserset
 }
 
 func (wg *WeightedAuthorizationModelGraph) calculateEdgeWildcards(edge *WeightedAuthorizationModelEdge) {
@@ -437,8 +453,9 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightFromTheEdges(nodeI
 		return tupleCycles, nil
 	}
 
-	// there is a cycle but the node is not responsible for the cycle and it is not an operator node
-	if node.nodeType != OperatorNode {
+	// there is a cycle but the node is not responsible for the cycle and it is not a logical operator node
+	// a logical operator node is an operator node, a logical ttu and a logical userset node
+	if !wg.isLogicalOperator(node) {
 		// even when there is a cycle, if the relation is not recursive then we calculate the weight using the max strategy
 		err = wg.calculateNodeWeightWithMaxStrategy(nodeID)
 		if err != nil {
@@ -447,8 +464,9 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightFromTheEdges(nodeI
 		return tupleCycles, nil
 	}
 
-	// if the node is an union operator and there is a cycle
-	if node.nodeType == OperatorNode && node.label == UnionOperator {
+	// if the node is a logical union operator,
+	// a logical union operator is a union node, a logical userset or a logical ttu.
+	if wg.isLogicalUnionOperator(node) {
 		// if the node is the reference node of the cycle, recalculate the weight, solve the depencies and remove the node from the tuple cycle
 		if wg.isNodeTupleCycleReference(nodeID, tupleCycles) {
 			err := wg.calculateNodeWeightAndFixDependencies(nodeID, tupleCycleDependencies)
@@ -500,23 +518,21 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithMaxStrategy(no
 // For all
 func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithMixedStrategy(nodeID string) error {
 	node := wg.nodes[nodeID]
-	weights := make(map[string]int)
 	edges := wg.edges[nodeID]
 
 	if len(edges) == 0 && node.nodeType != SpecificType && node.nodeType != SpecificTypeWildcard {
 		return fmt.Errorf("%w: %s node does not have any terminal type to reach to", ErrInvalidModel, node.uniqueLabel)
 	}
 
-	for idx, edge := range edges {
-		for key, value := range edge.weights {
-			if _, ok := weights[key]; !ok {
-				if idx != len(edges)-1 {
-					// This is the A edge.  We take the max weight of all key
-					weights[key] = value
-				} // otherwise, B edge requires weight to be present in A. Otherwise, we will ignore.
-			} else {
-				weights[key] = int(math.Max(float64(weights[key]), float64(value)))
-			}
+	// with the logical ttu and userset, an exclusion operation only has two edges
+	// the first edge is the one that defines the userset, the second edge is the one that excludes it
+	if len(edges) != 2 {
+		return fmt.Errorf("%w: invalid number of edges for exclusion node %s", ErrInvalidModel, nodeID)
+	}
+	weights := edges[0].weights
+	for key, value := range edges[1].weights {
+		if w, ok := weights[key]; ok {
+			weights[key] = int(math.Max(float64(w), float64(value)))
 		}
 	}
 
@@ -536,19 +552,9 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithEnforceTypeStr
 		return fmt.Errorf("%w: %s node does not have any terminal type to reach to", ErrInvalidModel, node.uniqueLabel)
 	}
 
-	// In intersection, directly-assignable types must be handled separately from rewritten types.
-	// All types flatten to edges, but directly-assignable weights are OR'd together, and that result
-	// is then AND'd with the combined weights of the rewritten edges for validity and weight assignment.
-	directlyAssignableWeights := make(map[string]int, len(edges))
 	rewriteWeights := make(map[string]int, len(edges))
-
 	for _, edge := range edges {
-		if edge.GetEdgeType() == DirectEdge {
-			for key, weight := range edge.weights {
-				directlyAssignableWeights[key] = weight
-			}
-			continue
-		}
+
 		if len(rewriteWeights) == 0 {
 			for key, weight := range edge.weights {
 				rewriteWeights[key] = weight
@@ -564,18 +570,7 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithEnforceTypeStr
 		}
 	}
 
-	if len(directlyAssignableWeights) > 0 {
-		for key := range directlyAssignableWeights {
-			if _, existsInBoth := rewriteWeights[key]; existsInBoth {
-				if node.weights == nil {
-					node.weights = make(map[string]int, int(math.Min(float64(len(rewriteWeights)), float64(len(directlyAssignableWeights)))))
-				}
-				node.weights[key] = int(math.Max(float64(rewriteWeights[key]), float64(directlyAssignableWeights[key])))
-			}
-		}
-	} else {
-		node.weights = rewriteWeights
-	}
+	node.weights = rewriteWeights
 
 	if len(node.weights) == 0 {
 		return fmt.Errorf("%w: not all paths return the same type for the node %s", ErrInvalidModel, nodeID)
@@ -605,8 +600,8 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightAndFixDependencies
 	referenceNodeID := "R#" + nodeID
 	edges := wg.edges[nodeID]
 
-	if (node.nodeType == OperatorNode && node.label != UnionOperator) || (node.nodeType != SpecificTypeAndRelation && node.nodeType != OperatorNode) {
-		return fmt.Errorf("%w: invalid node, reference node is not a union operator or a relation: %s", ErrTupleCycle, nodeID)
+	if node.nodeType != SpecificTypeAndRelation && !wg.isLogicalUnionOperator(node) {
+		return fmt.Errorf("%w: invalid node, reference node is not a union operator or a relation or a logical userset or logical TTU: %s", ErrTupleCycle, nodeID)
 	}
 
 	if len(edges) == 0 && node.nodeType != SpecificType && node.nodeType != SpecificTypeWildcard {

--- a/pkg/go/graph/weighted_graph.go
+++ b/pkg/go/graph/weighted_graph.go
@@ -515,13 +515,16 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithMaxStrategy(no
 // calculateNodeWeightWithMixedStrategy is a mixed weight strategy used for exclusion node (A but not B).
 // For all A edges, we take all the types for all the edges and get the max value
 // if more than one edge have the same type in their weights.
-// For all
 func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithMixedStrategy(nodeID string) error {
 	node := wg.nodes[nodeID]
 	edges := wg.edges[nodeID]
 
 	if len(edges) == 0 && node.nodeType != SpecificType && node.nodeType != SpecificTypeWildcard {
 		return fmt.Errorf("%w: %s node does not have any terminal type to reach to", ErrInvalidModel, node.uniqueLabel)
+	}
+
+	if node.nodeType != OperatorNode && node.label != ExclusionOperator {
+		return fmt.Errorf("%w: node %s cannot apply mixed strategy, only accepted exclusion nodes", ErrInvalidModel, nodeID)
 	}
 
 	// with the logical ttu and userset, an exclusion operation only has two edges

--- a/pkg/go/graph/weighted_graph.go
+++ b/pkg/go/graph/weighted_graph.go
@@ -525,7 +525,7 @@ func (wg *WeightedAuthorizationModelGraph) calculateNodeWeightWithMixedStrategy(
 		return fmt.Errorf("%w: %s node does not have any terminal type to reach to", ErrInvalidModel, node.uniqueLabel)
 	}
 
-	if node.nodeType != OperatorNode && node.label != ExclusionOperator {
+	if node.nodeType != OperatorNode || node.label != ExclusionOperator {
 		return fmt.Errorf("%w: node %s cannot apply mixed strategy, only accepted exclusion nodes", ErrInvalidModel, nodeID)
 	}
 

--- a/pkg/go/graph/weighted_graph_builder.go
+++ b/pkg/go/graph/weighted_graph_builder.go
@@ -126,11 +126,11 @@ func (wgb *WeightedAuthorizationModelGraphBuilder) parseTupleToUserset(wg *Weigh
 	node := parentNode
 	if parentNode.nodeType != SpecificTypeAndRelation && len(directlyRelated) > 1 {
 		uniqueLabel := typeDef.GetType() + "#ttu:" + tuplesetRelation + "#" + computedRelation
+		// add a logical ttu node for grouping of TTU that are part of the same tuplesetrelation and computed relation
 		logicalNode := wg.GetOrAddNode(uniqueLabel, uniqueLabel, LogicalTTUGrouping)
 		wg.AddEdge(parentNode.uniqueLabel, logicalNode.uniqueLabel, TTULogicalEdge, parentRelationName, typeTuplesetRelation, nil)
 		node = logicalNode
 	}
-	// add a logical ttu node for grouping of TTU that are part of the same tuplesetrelation and computed relation
 
 	for _, relatedType := range directlyRelated {
 		tuplesetType := relatedType.GetType()

--- a/pkg/go/graph/weighted_graph_builder.go
+++ b/pkg/go/graph/weighted_graph_builder.go
@@ -126,7 +126,7 @@ func (wgb *WeightedAuthorizationModelGraphBuilder) parseTupleToUserset(wg *Weigh
 	node := parentNode
 	if parentNode.nodeType != SpecificTypeAndRelation && len(directlyRelated) > 1 {
 		uniqueLabel := typeDef.GetType() + "#ttu:" + tuplesetRelation + "#" + computedRelation
-		logicalNode := wg.GetOrAddNode(uniqueLabel, uniqueLabel, LogicalTTU)
+		logicalNode := wg.GetOrAddNode(uniqueLabel, uniqueLabel, LogicalTTUGrouping)
 		wg.AddEdge(parentNode.uniqueLabel, logicalNode.uniqueLabel, TTULogicalEdge, parentRelationName, typeTuplesetRelation, nil)
 		node = logicalNode
 	}
@@ -184,7 +184,7 @@ func (wgb *WeightedAuthorizationModelGraphBuilder) parseThis(wg *WeightedAuthori
 	// add a logical userset node for grouping of direct usersets that are defined in the same relation
 	if parentNode.nodeType != SpecificTypeAndRelation && len(directlyRelated) > 1 {
 		uniqueLabel := typeDef.GetType() + "#direct:" + relation
-		logicalNode := wg.GetOrAddNode(uniqueLabel, uniqueLabel, LogicalUserset)
+		logicalNode := wg.GetOrAddNode(uniqueLabel, uniqueLabel, LogicalDirectGrouping)
 		wg.AddEdge(parentNode.uniqueLabel, logicalNode.uniqueLabel, DirectLogicalEdge, parentRelationName, "", nil)
 		node = logicalNode
 	}

--- a/pkg/go/graph/weighted_graph_builder_test.go
+++ b/pkg/go/graph/weighted_graph_builder_test.go
@@ -521,11 +521,16 @@ func TestCompleteWeightedGraphWithExclusion(t *testing.T) {
 		orNode := graph.edges[butnotNode.uniqueLabel][0].to
 		orEdges := graph.edges[orNode.uniqueLabel]
 		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[0].GetEdgeType())
-		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[1].GetEdgeType())
-		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[2].GetEdgeType())
+		require.Equal(t, DirectLogicalEdge, orEdges[0].GetEdgeType())
+		logicalUsersetNode := orEdges[0].to
+		require.Equal(t, LogicalUserset, logicalUsersetNode.GetNodeType())
+		directEdges := graph.edges[logicalUsersetNode.uniqueLabel]
+		require.Equal(t, DirectEdge, directEdges[0].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[0].GetRelationDefinition())
+		require.Equal(t, DirectEdge, directEdges[1].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[1].GetRelationDefinition())
+		require.Equal(t, DirectEdge, directEdges[2].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[2].GetRelationDefinition())
 	})
 	t.Run("B_appears_in_A_finite", func(t *testing.T) {
 		model := `
@@ -558,11 +563,16 @@ func TestCompleteWeightedGraphWithExclusion(t *testing.T) {
 		orNode := graph.edges[butnotNode.uniqueLabel][0].to
 		orEdges := graph.edges[orNode.uniqueLabel]
 		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[0].GetEdgeType())
-		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[1].GetEdgeType())
-		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[2].GetEdgeType())
+		require.Equal(t, DirectLogicalEdge, orEdges[0].GetEdgeType())
+		logicalUsersetNode := orEdges[0].to
+		require.Equal(t, LogicalUserset, logicalUsersetNode.GetNodeType())
+		directEdges := graph.edges[logicalUsersetNode.uniqueLabel]
+		require.Equal(t, DirectEdge, directEdges[0].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[0].GetRelationDefinition())
+		require.Equal(t, DirectEdge, directEdges[1].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[1].GetRelationDefinition())
+		require.Equal(t, DirectEdge, directEdges[2].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[2].GetRelationDefinition())
 	})
 	t.Run("B_not_appear_in_A", func(t *testing.T) {
 		model := `
@@ -596,9 +606,14 @@ func TestCompleteWeightedGraphWithExclusion(t *testing.T) {
 		orNode := graph.edges[butnotNode.uniqueLabel][0].to
 		orEdges := graph.edges[orNode.uniqueLabel]
 		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[0].GetEdgeType())
-		require.Equal(t, "group#allowed", orEdges[0].GetRelationDefinition())
-		require.Equal(t, DirectEdge, orEdges[1].GetEdgeType())
+		require.Equal(t, DirectLogicalEdge, orEdges[0].GetEdgeType())
+		logicalUsersetNode := orEdges[0].to
+		require.Equal(t, LogicalUserset, logicalUsersetNode.GetNodeType())
+		directEdges := graph.edges[logicalUsersetNode.uniqueLabel]
+		require.Equal(t, DirectEdge, directEdges[0].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[0].GetRelationDefinition())
+		require.Equal(t, DirectEdge, directEdges[1].GetEdgeType())
+		require.Equal(t, "group#allowed", directEdges[1].GetRelationDefinition())
 	})
 }
 

--- a/pkg/go/graph/weighted_graph_edge.go
+++ b/pkg/go/graph/weighted_graph_edge.go
@@ -1,5 +1,22 @@
 package graph
 
+type EdgeType int64
+
+const (
+	DirectEdge        EdgeType = 0
+	RewriteEdge       EdgeType = 1
+	TTUEdge           EdgeType = 2
+	ComputedEdge      EdgeType = 3
+	DirectLogicalEdge EdgeType = 4
+	TTULogicalEdge    EdgeType = 5
+	// When an edge does not have cond in the model, it will have a condition with value none.
+	// This is required to differentiate when an edge need to support condition and no condition
+	// like define rel1: [user, user with condX], in this case the edge will have [none, condX]
+	// or an edge needs to support only condition like define rel1: [user with condX], the edge will have [condX]
+	// in the case the edge does not have any condition like define rel1: [user], the edge will have [none].
+	NoCond string = "none"
+)
+
 type WeightedAuthorizationModelEdge struct {
 	weights            map[string]int
 	edgeType           EdgeType

--- a/pkg/go/graph/weighted_graph_edge.go
+++ b/pkg/go/graph/weighted_graph_edge.go
@@ -3,12 +3,50 @@ package graph
 type EdgeType int64
 
 const (
-	DirectEdge        EdgeType = 0
-	RewriteEdge       EdgeType = 1
-	TTUEdge           EdgeType = 2
-	ComputedEdge      EdgeType = 3
+	// DirectEdge leads directly to a single type or type#rel
+	//
+	// e.g. define rel1: [user]
+	// define rel2: [group#member]
+	//define rel2: [user, employee, user:*, user:* with xcond, employee with xcond, group#member, group#member with xcond]
+	DirectEdge EdgeType = 0
+
+	// RewriteEdge leads from an operator to a relation
+	//
+	// in `define rel1: a OR b`, the edge from `OR --> b` and the edge from rel1 -> OR
+	RewriteEdge EdgeType = 1
+
+	// TTUEdge points to a tuple to userset relation
+	//
+	// e.g. define rel1: admin from parent
+	TTUEdge EdgeType = 2
+
+	// ComputedEdge points to another relation
+	//
+	// e.g. define rel1: rel2
+	ComputedEdge EdgeType = 3
+
+	// DirectLogicalEdge points to the LogicalDirectGrouping of multiple direct edges that are part of an operator node
+	//
+	// define rel1: [user, employee, group#member] or rel2
+	// in this case OR node has two edges, one rewrite edge that goes to rel2 and another one that goes the direct edges grouping
+	// however, when there is not operator node involved then the LogicalDirectGrouping is not created to avoid unnecesary nested nodes creation
+	// for example in this use case,
+	// define rel1: [user, employee, group#member]
+	// the node rel1 has three direct edges
 	DirectLogicalEdge EdgeType = 4
-	TTULogicalEdge    EdgeType = 5
+
+	// TTULogicalEdge points to the LogicalTTUGrouping when a TTU has multiple possible parents and are part of an operator node
+	// For example, if both team and group below had a #viewer relation and viewer from parent is defined as part of a union operation
+	// then a new node is create to group the TTUs
+	//
+	// define parent: [team, group]
+	// define can_view: viewer from parent or member
+	// however, when there is not operator node involved then the LogicalTTUGrouping is not created to avoid unnecesary nested nodes creation
+	// for example in this use case no LogicalTTUGrouping is created, the two ttu edges are referenced directly from the can_view relation node
+	// define can_view: viewer from parent
+	// define parent: [team, group]
+	TTULogicalEdge EdgeType = 5
+
 	// When an edge does not have cond in the model, it will have a condition with value none.
 	// This is required to differentiate when an edge need to support condition and no condition
 	// like define rel1: [user, user with condX], in this case the edge will have [none, condX]

--- a/pkg/go/graph/weighted_graph_node.go
+++ b/pkg/go/graph/weighted_graph_node.go
@@ -1,5 +1,20 @@
 package graph
 
+type NodeType int64
+
+const (
+	SpecificType            NodeType = 0 // e.g. `group`
+	SpecificTypeAndRelation NodeType = 1 // e.g. `group#viewer`
+	OperatorNode            NodeType = 2 // e.g. union
+	SpecificTypeWildcard    NodeType = 3 // e.g. `group:*`
+	LogicalDirectGrouping   NodeType = 4 // e.g. `[user, employee, type1#rel]`
+	LogicalTTUGrouping      NodeType = 5 // e.g. `member from parent, wherer parent can have multiple terminal types`
+
+	UnionOperator        = "union"
+	IntersectionOperator = "intersection"
+	ExclusionOperator    = "exclusion"
+)
+
 type WeightedAuthorizationModelNode struct {
 	weights           map[string]int
 	nodeType          NodeType


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

To simplify graph operations, the system now introduces logical nodes (LogicalUsersetNode, LogicalTTUNode) to group related edges together. 🤝

Previously, multiple direct user assignments or multiple "tuple-to-userset" (TTU) edges were treated individually, which complicated algorithms, especially during algebraic operations.

Now, these new "union" nodes are created dynamically to consolidate multiple edges into a single logical unit, significantly reducing complexity for core processes like Check and ListObjects.

## Description
The Challenge: Simplifying Complex Edge Relationships
The previous weighted graph model did not inherently group multiple direct userset assignments or multiple "tuple-to-userset" (TTU) edges, even when they originated from the same definition. This created significant implementation challenges for core algorithms in OpenFGA, especially when performing algebraic operations. Essentially, the system failed to treat multiple direct edges or multiple TTU edges as a single logical union, unnecessarily increasing complexity.

The Solution: Introducing Logical Nodes and Edges
To reduce complexity in the Check, ListObjects, and indexer compilation algorithms, we are introducing two new types of "union" nodes and two corresponding "rewrite" edges. These new structures help group related edges into single, manageable units.

New Node Types:
LogicalUsersetNode: Consolidates multiple direct user assignments.
LogicalTTUNode: Consolidates multiple TTU edges that belong to the same definition.

New Edge Types:
DirectLogicalEdge: A rewrite edge connecting to a LogicalUsersetNode.
TTULogicalEdge: A rewrite edge connecting to a LogicalTTUNode.

How It Works: Creation Logic
These new logical nodes are created dynamically under specific conditions:

A LogicalUsersetNode is created when an algebraic operation involves more than one direct edge. All relevant direct edges are then extracted and connected to this new logical node.

A LogicalTTUNode is created when an algebraic operation involves more than one TTU edge from the same definition. These TTU edges are then extracted and grouped under the new logical node.
#### What problem is being solved?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces logical grouping nodes and logical edge kinds, so graphs may show additional intermediate nodes/edges when multiple relations are grouped.
  - Graphs expose richer edge/node metadata and weights for clearer topology and reasoning.

- Refactor
  - Consolidates handling of unions, cycles, and weight assignment across logical operators for more consistent behavior and clearer error messaging.

- Tests
  - Updated and expanded tests to validate new logical nodes, adjusted graph sizes, structures, and weight expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->