### PR TITLE
fixed recursive nested tuple cycles assignations

### DIFF
--- a/pkg/go/graph/weighted_graph.go
+++ b/pkg/go/graph/weighted_graph.go
@@ -656,6 +656,7 @@ func assignTupleCycleMetadata(edgesInCycle []*WeightedAuthorizationModelEdge) {
 // because AND or a BUT NOT are not allowed in a tuple cycle.
 func (wg *WeightedAuthorizationModelGraph) fixDependantEdgesWeight(nodeCycle string, referenceNodeID string, references []string, tupleCycleDependencies map[string][]*WeightedAuthorizationModelEdge) {
 	node := wg.nodes[nodeCycle]
+	tupleCycle := node.tupleCycle
 
 	// for each edge recorded to be dependent on the reference node, we need to update the weight
 	for _, edge := range tupleCycleDependencies[nodeCycle] {
@@ -689,6 +690,9 @@ func (wg *WeightedAuthorizationModelGraph) fixDependantEdgesWeight(nodeCycle str
 		}
 		edge.weights = edgeWeights
 		wg.addReferentialWildcardsToEdge(edge, nodeCycle)
+		if tupleCycle {
+			edge.tupleCycle = true
+		}
 	}
 }
 
@@ -697,7 +701,7 @@ func (wg *WeightedAuthorizationModelGraph) fixDependantEdgesWeight(nodeCycle str
 // because AND or a BUT NOT are not allowed in a tuple cycle.
 func (wg *WeightedAuthorizationModelGraph) fixDependantNodesWeight(nodeCycle string, referenceNodeID string, tupleCycleDependencies map[string][]*WeightedAuthorizationModelEdge) {
 	node := wg.nodes[nodeCycle]
-
+	tupleCycle := node.tupleCycle
 	for _, edge := range tupleCycleDependencies[nodeCycle] {
 		fromNode := wg.nodes[edge.from.uniqueLabel]
 		nodeWeights := make(map[string]int)
@@ -719,6 +723,9 @@ func (wg *WeightedAuthorizationModelGraph) fixDependantNodesWeight(nodeCycle str
 			}
 		}
 		fromNode.weights = nodeWeights
+		if tupleCycle {
+			fromNode.tupleCycle = true
+		}
 		wg.addReferentialWildcardsToNode(edge.from.uniqueLabel, nodeCycle)
 	}
 }

--- a/pkg/go/graph/weighted_graph_test.go
+++ b/pkg/go/graph/weighted_graph_test.go
@@ -1209,7 +1209,7 @@ func TestValidMixedRecursionWithTupleCycles(t *testing.T) {
 
 	require.True(t, graph.nodes["state-member"].tupleCycle)
 	require.True(t, graph.nodes["state-member-or"].tupleCycle)
-	require.False(t, graph.nodes["state-member-or-or"].tupleCycle)
+	require.True(t, graph.nodes["state-member-or-or"].tupleCycle)
 	require.False(t, graph.nodes["state-parent"].tupleCycle)
 	require.True(t, graph.nodes["state-parent_member"].tupleCycle)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
For recursive nested tuples cycles model, some edges were missing the tuple cycle flag. This issue does not affect the weight of the node or the edge that are part of the tuple cycle. The weight is correctly calculated in the recursion or cycles, but the inclusion of all possible edges as part of the tuple cycle was missing some use cases. 
## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
For example for a model like this:
model
	schema 1.1
type user
type document
	relations
		define viewer: [team#member, org#employee]
type team
	relations
		define member: [user, document#viewer, org#employee]
type org
	relations
		define employee: [user, document#viewer, team#member]

All the edges were part of the tuple cycle except the las edge between document#viewer and the org#employee, and the reason was the org#employee was already declared as part of tuple cycles and had a referential weight based on document#viewer. However, the edge between document#viewer and org@employee didn't detect a cycle because the node was already visited, and a cycle was already detected.
#### How is it being solved?
When fixing the referential weight in the presence of a cycle if the node owning the reference id has the tuple cycles all the dependent cycles edges needed to be declared as a tuple cycle.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

