### PR TITLE
chore: ignore gradle/actions/setup-gradle v6 in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,6 +15,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "gradle/actions/setup-gradle"
+        versions: [">= 6.0.0, < 7.0.0"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
gradle/actions/setup-gradle v6 introduced a licensing change requiring acceptance of new Terms of Use tied to a proprietary caching component. The ToS language is broad and legally ambiguous, raising concerns about IP rights over cached build artifacts (e.g. sources.jar).

Key concerns:
- ToS grants Gradle broad rights over "user submissions", unclear scope
- Disabling the new caching also disables Gradle distribution caching (known bug)
- No clear legal guidance for private/commercial repos yet

Gradle maintainers have stated no data is currently sent to Gradle and plan to clarify the ToS, but until that happens we stay on v5 to avoid accidental acceptance of unclear terms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to ignore specific GitHub Actions dependency updates within a designated version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->