### PR TITLE
chore: upgrade gradle/actions from v4 to v6.1.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "gradle/actions/setup-gradle"
-        versions: [">= 6.0.0, < 7.0.0"]
+        versions: [">= 6.0.0, < 6.1.0"]
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/pkg-java-release.yaml
+++ b/.github/workflows/pkg-java-release.yaml
@@ -37,10 +37,12 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v4
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic # Use the open-source basic cache provider
 
         # Tasks created by https://github.com/gradle-nexus/publish-plugin
       - name: Publish package
@@ -76,10 +78,12 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v4
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic # Use the open-source basic cache provider
 
       # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html
       - name: Publish package


### PR DESCRIPTION
Upgrades the gradle/actions used in the Java release workflow:
  - gradle/actions/wrapper-validation: v4 → v6.1.0
  - gradle/actions/setup-gradle: v4 → v6.1.0

  Adds `cache-provider: basic` to all setup-gradle steps to explicitly
  use the open-source basic cache provider.

  Updates dependabot ignore range for gradle/actions/setup-gradle from
  `>= 6.0.0, < 7.0.0` to `>= 6.0.0, < 6.1.0` to allow future v6.1.x+
  updates to be picked up automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions and configurations for build workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->