### PR TITLE
chore: ignore eslint 10.x updates in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,7 +38,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "eslint"
-        versions: [">= 10.0.0, < 11.0.0"]
+        versions: [">=10.0.0 <11.0.0"]
     groups:
       dependencies:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,6 +36,9 @@ updates:
     directory: "/pkg/js"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">= 10.0.0, < 11.0.0"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
Update will need to be performed manually