### PR TITLE
chore: release gate on merge and marking prerelease tags

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -43,6 +43,13 @@ concurrency:
 
 jobs:
   release:
+    # Phase 1 runs on manual dispatch. Phase 2 runs on push to main ONLY when
+    # the merged commit is a release commit (`release: ...`). Routine merges to
+    # main therefore never invoke release-please, so they never spawn release
+    # PRs; only a merged release PR drives the publish path.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'release:')
     uses: ./.github/workflows/reusable-release-please.yaml
     permissions:
       contents: write

--- a/.github/workflows/reusable-release-please.yaml
+++ b/.github/workflows/reusable-release-please.yaml
@@ -159,9 +159,18 @@ jobs:
           fi
 
       - name: Run release-please
-        # We intentionally do not consume this action's outputs: skip-github-release
-        # is set in the config, so release/tag outputs are not produced. The
-        # post-release job derives everything from the manifest diff instead.
+        # Runs on BOTH dispatch and push:
+        #   - dispatch (target-branch=release): opens/maintains the release PR(s).
+        #   - push of a `release:` commit (target-branch=main): does the
+        #     bookkeeping on the merged PR (flips autorelease labels, adds the
+        #     "release created" comment). `skip-github-release: true` in the
+        #     config means it does NOT cut a tag/release here; the post-release
+        #     job creates the signed tag + draft release instead.
+        # Routine (non-release) pushes never reach this step because the caller
+        # only invokes the workflow on push when the head commit starts with
+        # `release:`.
+        #
+        # We intentionally do not consume this action's outputs.
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -298,12 +307,24 @@ jobs:
               NOTES=$(printf '%s\n\n%s\n' "${NOTES}" "${AUTO_NOTES}")
             fi
 
-            # 5) Create a draft GitHub release.
+            # 4b) Flag pre-release versions (anything not X.Y.Z, e.g. -beta.1,
+            #     -rc.2) so the GitHub release is marked as a pre-release.
+            #     Empty array expands to zero args when the version is stable.
+            PRERELEASE_FLAG=()
+            if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              PRERELEASE_FLAG=(--prerelease)
+            fi
+
+            # 5) Create (or refresh) the draft GitHub release. On an existing
+            #    release we update notes/pre-release flag but deliberately do
+            #    NOT pass --draft, so a release already published by the
+            #    registry workflow is never silently re-drafted.
             if gh release view "${tag}" >/dev/null 2>&1; then
-              echo "Release ${tag} already exists; skipping"
+              echo "Release ${tag} already exists; refreshing notes"
+              gh release edit "${tag}" --title "${tag}" --notes "${NOTES}" "${PRERELEASE_FLAG[@]}"
             else
               echo "Creating draft release ${tag}"
-              gh release create "${tag}" --title "${tag}" --notes "${NOTES}" --draft
+              gh release create "${tag}" --title "${tag}" --notes "${NOTES}" --draft "${PRERELEASE_FLAG[@]}"
             fi
           done
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This just ensures that release-please runs only on "release: " prefix PR merges or when triggered from workflow dispatch.

Another thing it does is marks beta/alpha/ other experimental tags as prerelease instead of latest like we do in the other SDKs.

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

