### PR TITLE
fix(go): handle proto direct assignments in DSL transform

### DIFF
--- a/pkg/go/transformer/dsltojson.go
+++ b/pkg/go/transformer/dsltojson.go
@@ -307,7 +307,9 @@ func (l *OpenFgaDslListener) EnterRelationDefDirectAssignment(_ *parser.Relation
 }
 
 func (l *OpenFgaDslListener) ExitRelationDefDirectAssignment(_ *parser.RelationDefDirectAssignmentContext) {
-	partialRewrite := &openfgav1.Userset{Userset: &openfgav1.Userset_This{}}
+	partialRewrite := &openfgav1.Userset{
+		Userset: &openfgav1.Userset_This{This: &openfgav1.DirectUserset{}},
+	}
 
 	l.currentRelation.Rewrites = append(l.currentRelation.Rewrites, partialRewrite)
 }

--- a/pkg/go/transformer/jsontodsl.go
+++ b/pkg/go/transformer/jsontodsl.go
@@ -26,14 +26,24 @@ func (v *DirectAssignmentValidator) occurrences() int {
 	return v.occurred
 }
 
+func isDirectAssignment(userset *openfgav1.Userset) bool {
+	if userset == nil {
+		return false
+	}
+
+	_, ok := userset.GetUserset().(*openfgav1.Userset_This)
+
+	return ok
+}
+
 func (v *DirectAssignmentValidator) isFirstPosition(userset *openfgav1.Userset) bool { //nolint:cyclop
-	if userset.GetThis() != nil {
+	if isDirectAssignment(userset) {
 		return true
 	}
 
 	switch {
 	case userset.GetDifference() != nil && userset.GetDifference().GetBase() != nil:
-		if userset.GetDifference().GetBase().GetThis() != nil {
+		if isDirectAssignment(userset.GetDifference().GetBase()) {
 			return true
 		}
 
@@ -45,7 +55,7 @@ func (v *DirectAssignmentValidator) isFirstPosition(userset *openfgav1.Userset) 
 		// so even if it is not in the first position here, we're fine
 		children := userset.GetIntersection().GetChild()
 		for _, child := range children {
-			if child.GetThis() != nil {
+			if isDirectAssignment(child) {
 				return true
 			}
 		}
@@ -56,7 +66,7 @@ func (v *DirectAssignmentValidator) isFirstPosition(userset *openfgav1.Userset) 
 		children := userset.GetUnion().GetChild()
 		if len(children) > 0 {
 			for _, child := range children {
-				if child.GetThis() != nil {
+				if isDirectAssignment(child) {
 					return true
 				}
 			}
@@ -204,7 +214,7 @@ func parseSubRelation(
 	typeRestrictions []*openfgav1.RelationReference,
 	validator *DirectAssignmentValidator,
 ) (string, error) {
-	if relationDefinition.GetThis() != nil {
+	if isDirectAssignment(relationDefinition) {
 		// Make sure we have no more than 1 reference for direct assignment in a given relation
 		validator.incr()
 
@@ -298,7 +308,7 @@ func prioritizeDirectAssignment(usersets []*openfgav1.Userset) []*openfgav1.User
 		thisPosition := -1
 
 		for index, userset := range usersets {
-			if userset.GetThis() != nil {
+			if isDirectAssignment(userset) {
 				thisPosition = index
 
 				break

--- a/pkg/go/transformer/jsontodsl_test.go
+++ b/pkg/go/transformer/jsontodsl_test.go
@@ -8,6 +8,33 @@ import (
 	language "github.com/openfga/language/pkg/go/transformer"
 )
 
+func TestTransformJSONProtoToDSL(t *testing.T) {
+	t.Parallel()
+
+	testCases, err := loadModuleTestCases()
+	require.NoError(t, err)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			if len(testCase.Modules) == 0 || testCase.Skip || len(testCase.ExpectedErrors) > 0 {
+				t.Skip()
+			}
+
+			model, err := language.TransformModuleFilesToModel(testCase.Modules, "1.2")
+			require.NoError(t, err)
+
+			dsl, err := language.TransformJSONProtoToDSL(model, language.WithIncludeSourceInformation(false))
+			require.NoError(t, err)
+			require.Equal(t, testCase.DSL, dsl)
+
+			dslWithSrc, err := language.TransformJSONProtoToDSL(model, language.WithIncludeSourceInformation(true))
+			require.NoError(t, err)
+			require.Equal(t, testCase.DSLWithSourceInfo, dslWithSrc)
+		})
+
+	}
+}
 func TestJSONToDSLTransformer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

  Fixes `TransformJSONProtoToDSL` for in-memory authorization models produced by `TransformModuleFilesToModel` when relations contain direct
  assignments.

  #### What problem is being solved?

  Direct assignments are represented by the `Userset_This` protobuf oneof case. The previous implementation detected direct assignments with
  `GetThis() != nil`, which can fail when the oneof case is set but the inner `DirectUserset` sentinel is nil.

  This caused valid module models to fail when round-tripping through:

  ```text
  TransformModuleFilesToModel -> TransformJSONProtoToDSL
```
  #### How is it being solved?

  TransformJSONProtoToDSL now detects direct assignments by checking whether the userset is the Userset_This oneof case, instead of
  requiring GetThis() to return a populated DirectUserset.

  The DSL-to-proto transformer also now populates DirectUserset when creating direct-assignment rewrites.

  #### What changes are made to solve it?

  - Detect direct assignments by checking the Userset_This oneof case.
  - Populate DirectUserset when transforming DSL direct assignments to proto.
  - Add module round-trip test coverage for TransformJSONProtoToDSL, with and without source information.

  ## References

  closes https://github.com/openfga/language/issues/620

## Review Checklist
- [x ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of direct assignments when converting between JSON/protobuf and DSL, making rewritten output more consistent and reliable.
  * Fixed direct-assignment detection in nested relation cases so conversion results are handled correctly across different rewrite paths.

* **Tests**
  * Added coverage for JSON-to-DSL conversion, including output with and without source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->