### PR TITLE
fix(ci): grant contents read to java release test job

### DIFF
--- a/.github/workflows/pkg-java-release.yaml
+++ b/.github/workflows/pkg-java-release.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   test:
-    permissions: {}
+    permissions:
+      contents: read
     uses: ./.github/workflows/pkg-java-build.yaml
     secrets: inherit
 


### PR DESCRIPTION
The test job in pkg-java-release.yaml used 'permissions: {}', but the called reusable workflow (pkg-java-build.yaml) requires 'contents: read'. Since a caller cannot grant fewer permissions than the callee requests, the tag-triggered run for pkg/java/v0.2.1 failed at startup (startup_failure), so the Maven Central / GitHub Packages publish jobs never ran and the draft release was never finalized.

https://github.com/openfga/language/actions/runs/28814728897

```
[Invalid workflow file: .github/workflows/pkg-java-release.yaml#L10](https://github.com/openfga/language/actions/runs/28814728897/workflow)
The workflow is not valid. .github/workflows/pkg-java-release.yaml (Line: 10, Col: 3): Error calling workflow 'openfga/language/.github/workflows/pkg-java-build.yaml@9049a8c161032eb9e9739cc4ac1d7f25ea0304be'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java release process permissions to ensure the workflow can access repository contents during tests, improving release automation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->