### PR TITLE
chore(ci/java): derive publish coordinates from project instead of hardcoded values

### DIFF
--- a/pkg/java/build.gradle
+++ b/pkg/java/build.gradle
@@ -16,10 +16,10 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
-apply from: 'publish.gradle'
-
 group = 'dev.openfga'
 version = '0.2.1' // x-release-please-version
+
+apply from: 'publish.gradle'
 
 repositories {
     mavenCentral()

--- a/pkg/java/publish.gradle
+++ b/pkg/java/publish.gradle
@@ -4,10 +4,7 @@ publishing {
             from components.java
 
             pom {
-                group = 'dev.openfga'
-                artifactId = 'openfga-language'
                 name = 'openfga-language'
-                version = 'v0.2.0-beta.2'
                 description = 'OpenFGA Language package: transformers, validators and more'
                 url = 'https://openfga.dev'
                 licenses {


### PR DESCRIPTION


publish.gradle hardcoded version = 'v0.2.0-beta.2' in the maven POM, overriding the release-please-managed version in build.gradle. Every publish therefore retried the old beta artifact, failing with 409 Conflict on GitHub Packages and 'component already exists' on Sonatype.

Drop the hardcoded group/artifactId/version so they come from the project (group/version in build.gradle, artifactId from rootProject.name), and apply publish.gradle after group/version are set.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Java package build and publication configuration to improve build consistency and dependency ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->