### PR TITLE
fix(pkg/go/utils): match declarations by full name, not by prefix

### DIFF
--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -28,13 +28,12 @@ func IsNameByte(b byte) bool {
 	return nameBytes[b]
 }
 
-// declarationIndex returns the index of the first line beginning with prefix whose
-// name ends there, or -1. prefix always spans whole words (`type <name>`, `define
+// name ends there, or -1. Prefix always spans whole words (`type <name>`, `define
 // <name>`, `condition <name>`), so requiring the next byte to end the name is what
 // stops `document` matching a declaration of `documentation`.
-func declarationIndex(lines []string, prefix string, normalize func(string) string) int {
+func declarationIndex(lines []string, prefix string) int {
 	return slices.IndexFunc(lines, func(line string) bool {
-		trimmed := normalize(strings.TrimSpace(line))
+		trimmed := NormalizeWhitespace(strings.TrimSpace(line))
 		if !strings.HasPrefix(trimmed, prefix) {
 			return false
 		}
@@ -45,42 +44,78 @@ func declarationIndex(lines []string, prefix string, normalize func(string) stri
 	})
 }
 
-// keepSpaces leaves a line as-is. Only the relation helper collapses repeated
-// spaces, matching the reference, where ` {2,}` normalization is applied in
-// getRelationLineNumber alone.
-func keepSpaces(line string) string { return line }
+// isInlineWhitespace reports whether b is a byte the lexer's WHITESPACE rule
+// accepts between tokens on a line: space, tab or form feed (OpenFGALexer.g4).
+func isInlineWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\f'
+}
 
-// normalizeSpaces collapses runs of spaces into one, mirroring the reference's
-// ` {2,}` normalization, so `define  owner:` is matched the same as `define owner:`.
-func normalizeSpaces(line string) string {
-	for strings.Contains(line, "  ") {
-		line = strings.ReplaceAll(line, "  ", " ")
+// NormalizeWhitespace collapses every run of inline whitespace into one space, so
+// `define\towner:` and `define  owner:` are matched the same as `define owner:`.
+// Only space, tab and form feed are folded — exactly the lexer's WHITESPACE
+// alphabet; anything else (nbsp, vertical tab) fails to lex and can never reach a
+// line lookup. Lines that are already normal are returned unchanged.
+func NormalizeWhitespace(line string) string {
+	for i := range len(line) {
+		if b := line[i]; b == '\t' || b == '\f' || (b == ' ' && i > 0 && line[i-1] == ' ') {
+			return foldInlineWhitespace(line)
+		}
 	}
 
 	return line
 }
 
+func foldInlineWhitespace(line string) string {
+	var sb strings.Builder
+
+	sb.Grow(len(line))
+
+	inRun := false
+
+	for i := range len(line) {
+		if isInlineWhitespace(line[i]) {
+			inRun = true
+
+			continue
+		}
+
+		if inRun {
+			sb.WriteByte(' ')
+
+			inRun = false
+		}
+
+		sb.WriteByte(line[i])
+	}
+
+	if inRun {
+		sb.WriteByte(' ')
+	}
+
+	return sb.String()
+}
+
 // GetConditionLineNumber returns the index of the line declaring conditionName, or
 // -1. `less` does not match a declaration of `less_than`.
 func GetConditionLineNumber(conditionName string, lines []string) int {
-	return declarationIndex(lines, "condition "+conditionName, keepSpaces)
+	return declarationIndex(lines, "condition "+conditionName)
 }
 
 // GetTypeLineNumber returns the index of the line declaring typeName, or -1.
 // `document` does not match a declaration of `documentation`.
 func GetTypeLineNumber(typeName string, lines []string) int {
-	return declarationIndex(lines, "type "+typeName, keepSpaces)
+	return declarationIndex(lines, "type "+typeName)
 }
 
 // GetExtendedTypeLineNumber returns the index of the line extending typeName, or -1.
 func GetExtendedTypeLineNumber(typeName string, lines []string) int {
-	return declarationIndex(lines, "extend type "+typeName, keepSpaces)
+	return declarationIndex(lines, "extend type "+typeName)
 }
 
 // GetRelationLineNumber returns the index of the line defining relation, or -1.
 // `owner` does not match a definition of `owner_group`.
 func GetRelationLineNumber(relation string, lines []string) int {
-	return declarationIndex(lines, "define "+relation, normalizeSpaces)
+	return declarationIndex(lines, "define "+relation)
 }
 
 type StartEnd struct {

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -28,7 +28,8 @@ func IsNameByte(b byte) bool {
 	return nameBytes[b]
 }
 
-// name ends there, or -1. Prefix always spans whole words (`type <name>`, `define
+// declarationIndex returns the index of the first line beginning with prefix whose
+// name ends there, or -1. prefix always spans whole words (`type <name>`, `define
 // <name>`, `condition <name>`), so requiring the next byte to end the name is what
 // stops `document` matching a declaration of `documentation`.
 func declarationIndex(lines []string, prefix string) int {

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -5,21 +5,27 @@ import (
 	"strings"
 )
 
-// IsNameByte reports whether b can appear inside a declaration name. IDENTIFIER
-// admits letters, digits, `_` and MINUS, and EXTENDED_IDENTIFIER adds SLASH and DOT
+// nameBytes marks every byte that can appear inside a declaration name, keyed by
+// the bytes themselves so each entry is visibly correct. IDENTIFIER admits letters,
+// digits, `_` and MINUS, and EXTENDED_IDENTIFIER adds SLASH and DOT
 // (OpenFGALexer.g4), so `core.doc` is one name rather than `core` and a terminator.
+var nameBytes = [256]bool{
+	'a': true, 'b': true, 'c': true, 'd': true, 'e': true, 'f': true, 'g': true,
+	'h': true, 'i': true, 'j': true, 'k': true, 'l': true, 'm': true, 'n': true,
+	'o': true, 'p': true, 'q': true, 'r': true, 's': true, 't': true, 'u': true,
+	'v': true, 'w': true, 'x': true, 'y': true, 'z': true,
+	'A': true, 'B': true, 'C': true, 'D': true, 'E': true, 'F': true, 'G': true,
+	'H': true, 'I': true, 'J': true, 'K': true, 'L': true, 'M': true, 'N': true,
+	'O': true, 'P': true, 'Q': true, 'R': true, 'S': true, 'T': true, 'U': true,
+	'V': true, 'W': true, 'X': true, 'Y': true, 'Z': true,
+	'0': true, '1': true, '2': true, '3': true, '4': true,
+	'5': true, '6': true, '7': true, '8': true, '9': true,
+	'_': true, '-': true, '/': true, '.': true,
+}
+
+// IsNameByte reports whether b can appear inside a declaration name.
 func IsNameByte(b byte) bool {
-	switch {
-	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
-		return true
-	}
-
-	switch b {
-	case '_', '-', '/', '.':
-		return true
-	}
-
-	return false
+	return nameBytes[b]
 }
 
 // declarationIndex returns the index of the first line beginning with prefix whose

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+// intraLineWhitespace is the set of characters the grammar's WHITESPACE token
+// admits within a line: `WHITESPACE: ( '\t' | ' ' | '\u000C')+;` (OpenFGALexer.g4).
+// `\f` (U+000C) belongs here because the lexer prefers WHITESPACE over NEWLINE for
+// a bare `\f`, so `define owner\f: [user]` is a single valid line. Trimming a
+// narrower set would make such a declaration unfindable and collapse its reported
+// location to 0:0.
+const intraLineWhitespace = " \t\f"
+
 // declarationIndex returns the index of the first line that, once trimmed, begins
 // with prefix and whose remainder satisfies rest. Requiring the caller to validate
 // the remainder is what keeps a declaration whose name is a prefix of another
@@ -29,7 +37,7 @@ func endOrComment(rest string) bool {
 		return true
 	}
 
-	trimmed := strings.TrimLeft(rest, " \t")
+	trimmed := strings.TrimLeft(rest, intraLineWhitespace)
 	if trimmed == rest {
 		return false
 	}
@@ -39,7 +47,7 @@ func endOrComment(rest string) bool {
 
 // startsWith reports whether rest begins with sep, ignoring leading whitespace.
 func startsWith(rest, sep string) bool {
-	return strings.HasPrefix(strings.TrimLeft(rest, " \t"), sep)
+	return strings.HasPrefix(strings.TrimLeft(rest, intraLineWhitespace), sep)
 }
 
 // normalizeSpaces collapses runs of spaces into one, mirroring the reference's

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -5,27 +5,87 @@ import (
 	"strings"
 )
 
+// declarationIndex returns the index of the first line that, once trimmed, begins
+// with prefix and whose remainder satisfies rest. Requiring the caller to validate
+// the remainder is what keeps a declaration whose name is a prefix of another
+// (e.g. `type document` vs `type documentation`) from matching the wrong line.
+func declarationIndex(lines []string, prefix string, rest func(string) bool) int {
+	return slices.IndexFunc(lines, func(line string) bool {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, prefix) {
+			return false
+		}
+
+		return rest(trimmed[len(prefix):])
+	})
+}
+
+// endOrComment reports whether the remainder of a declaration line is empty or is
+// only a trailing comment, mirroring the reference's `^(\s+#.*)?$`. The `#` must be
+// preceded by whitespace so a `#` glued to the name isn't treated as a comment —
+// `type doc#x` is not a declaration of `doc`.
+func endOrComment(rest string) bool {
+	if rest == "" {
+		return true
+	}
+
+	trimmed := strings.TrimLeft(rest, " \t")
+	if trimmed == rest {
+		return false
+	}
+
+	return strings.HasPrefix(trimmed, "#")
+}
+
+// startsWith reports whether rest begins with sep, ignoring leading whitespace.
+func startsWith(rest, sep string) bool {
+	return strings.HasPrefix(strings.TrimLeft(rest, " \t"), sep)
+}
+
+// normalizeSpaces collapses runs of spaces into one, mirroring the reference's
+// ` {2,}` normalization, so `define  owner:` is matched the same as `define owner:`.
+func normalizeSpaces(line string) string {
+	for strings.Contains(line, "  ") {
+		line = strings.ReplaceAll(line, "  ", " ")
+	}
+
+	return line
+}
+
+// GetConditionLineNumber returns the index of the line declaring conditionName, or
+// -1. The parameter list's `(` must follow the name, so `less` does not match a
+// declaration of `less_than`.
 func GetConditionLineNumber(conditionName string, lines []string) int {
-	return slices.IndexFunc(lines, func(line string) bool {
-		return strings.HasPrefix(strings.TrimSpace(line), "condition "+conditionName)
+	return declarationIndex(lines, "condition "+conditionName, func(rest string) bool {
+		return startsWith(rest, "(")
 	})
 }
 
+// GetTypeLineNumber returns the index of the line declaring typeName, or -1. Only a
+// trailing comment may follow the name, so `document` does not match a declaration
+// of `documentation`.
 func GetTypeLineNumber(typeName string, lines []string) int {
-	return slices.IndexFunc(lines, func(line string) bool {
-		return strings.HasPrefix(strings.TrimSpace(line), "type "+typeName)
-	})
+	return declarationIndex(lines, "type "+typeName, endOrComment)
 }
 
+// GetExtendedTypeLineNumber returns the index of the line extending typeName, or -1.
+// The name must be followed only by a trailing comment, as in GetTypeLineNumber.
 func GetExtendedTypeLineNumber(typeName string, lines []string) int {
-	return slices.IndexFunc(lines, func(line string) bool {
-		return strings.HasPrefix(strings.TrimSpace(line), "extend type "+typeName)
-	})
+	return declarationIndex(lines, "extend type "+typeName, endOrComment)
 }
 
+// GetRelationLineNumber returns the index of the line defining relation, or -1. The
+// `:` must follow the name, so `owner` does not match a definition of `owner_group`.
 func GetRelationLineNumber(relation string, lines []string) int {
+	prefix := "define " + relation
+
 	return slices.IndexFunc(lines, func(line string) bool {
-		return strings.HasPrefix(strings.TrimSpace(line), "define "+relation)
+		normalized := normalizeSpaces(strings.TrimSpace(line))
+		if !strings.HasPrefix(normalized, prefix) {
+			return false
+		}
+
+		return startsWith(normalized[len(prefix):], ":")
 	})
 }
 

--- a/pkg/go/utils/line-numbers.go
+++ b/pkg/go/utils/line-numbers.go
@@ -5,50 +5,44 @@ import (
 	"strings"
 )
 
-// intraLineWhitespace is the set of characters the grammar's WHITESPACE token
-// admits within a line: `WHITESPACE: ( '\t' | ' ' | '\u000C')+;` (OpenFGALexer.g4).
-// `\f` (U+000C) belongs here because the lexer prefers WHITESPACE over NEWLINE for
-// a bare `\f`, so `define owner\f: [user]` is a single valid line. Trimming a
-// narrower set would make such a declaration unfindable and collapse its reported
-// location to 0:0.
-const intraLineWhitespace = " \t\f"
+// IsNameByte reports whether b can appear inside a declaration name. IDENTIFIER
+// admits letters, digits, `_` and MINUS, and EXTENDED_IDENTIFIER adds SLASH and DOT
+// (OpenFGALexer.g4), so `core.doc` is one name rather than `core` and a terminator.
+func IsNameByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+		return true
+	}
 
-// declarationIndex returns the index of the first line that, once trimmed, begins
-// with prefix and whose remainder satisfies rest. Requiring the caller to validate
-// the remainder is what keeps a declaration whose name is a prefix of another
-// (e.g. `type document` vs `type documentation`) from matching the wrong line.
-func declarationIndex(lines []string, prefix string, rest func(string) bool) int {
+	switch b {
+	case '_', '-', '/', '.':
+		return true
+	}
+
+	return false
+}
+
+// declarationIndex returns the index of the first line beginning with prefix whose
+// name ends there, or -1. prefix always spans whole words (`type <name>`, `define
+// <name>`, `condition <name>`), so requiring the next byte to end the name is what
+// stops `document` matching a declaration of `documentation`.
+func declarationIndex(lines []string, prefix string, normalize func(string) string) int {
 	return slices.IndexFunc(lines, func(line string) bool {
-		trimmed := strings.TrimSpace(line)
+		trimmed := normalize(strings.TrimSpace(line))
 		if !strings.HasPrefix(trimmed, prefix) {
 			return false
 		}
 
-		return rest(trimmed[len(prefix):])
+		rest := trimmed[len(prefix):]
+
+		return rest == "" || !IsNameByte(rest[0])
 	})
 }
 
-// endOrComment reports whether the remainder of a declaration line is empty or is
-// only a trailing comment, mirroring the reference's `^(\s+#.*)?$`. The `#` must be
-// preceded by whitespace so a `#` glued to the name isn't treated as a comment —
-// `type doc#x` is not a declaration of `doc`.
-func endOrComment(rest string) bool {
-	if rest == "" {
-		return true
-	}
-
-	trimmed := strings.TrimLeft(rest, intraLineWhitespace)
-	if trimmed == rest {
-		return false
-	}
-
-	return strings.HasPrefix(trimmed, "#")
-}
-
-// startsWith reports whether rest begins with sep, ignoring leading whitespace.
-func startsWith(rest, sep string) bool {
-	return strings.HasPrefix(strings.TrimLeft(rest, intraLineWhitespace), sep)
-}
+// keepSpaces leaves a line as-is. Only the relation helper collapses repeated
+// spaces, matching the reference, where ` {2,}` normalization is applied in
+// getRelationLineNumber alone.
+func keepSpaces(line string) string { return line }
 
 // normalizeSpaces collapses runs of spaces into one, mirroring the reference's
 // ` {2,}` normalization, so `define  owner:` is matched the same as `define owner:`.
@@ -61,40 +55,26 @@ func normalizeSpaces(line string) string {
 }
 
 // GetConditionLineNumber returns the index of the line declaring conditionName, or
-// -1. The parameter list's `(` must follow the name, so `less` does not match a
-// declaration of `less_than`.
+// -1. `less` does not match a declaration of `less_than`.
 func GetConditionLineNumber(conditionName string, lines []string) int {
-	return declarationIndex(lines, "condition "+conditionName, func(rest string) bool {
-		return startsWith(rest, "(")
-	})
+	return declarationIndex(lines, "condition "+conditionName, keepSpaces)
 }
 
-// GetTypeLineNumber returns the index of the line declaring typeName, or -1. Only a
-// trailing comment may follow the name, so `document` does not match a declaration
-// of `documentation`.
+// GetTypeLineNumber returns the index of the line declaring typeName, or -1.
+// `document` does not match a declaration of `documentation`.
 func GetTypeLineNumber(typeName string, lines []string) int {
-	return declarationIndex(lines, "type "+typeName, endOrComment)
+	return declarationIndex(lines, "type "+typeName, keepSpaces)
 }
 
 // GetExtendedTypeLineNumber returns the index of the line extending typeName, or -1.
-// The name must be followed only by a trailing comment, as in GetTypeLineNumber.
 func GetExtendedTypeLineNumber(typeName string, lines []string) int {
-	return declarationIndex(lines, "extend type "+typeName, endOrComment)
+	return declarationIndex(lines, "extend type "+typeName, keepSpaces)
 }
 
-// GetRelationLineNumber returns the index of the line defining relation, or -1. The
-// `:` must follow the name, so `owner` does not match a definition of `owner_group`.
+// GetRelationLineNumber returns the index of the line defining relation, or -1.
+// `owner` does not match a definition of `owner_group`.
 func GetRelationLineNumber(relation string, lines []string) int {
-	prefix := "define " + relation
-
-	return slices.IndexFunc(lines, func(line string) bool {
-		normalized := normalizeSpaces(strings.TrimSpace(line))
-		if !strings.HasPrefix(normalized, prefix) {
-			return false
-		}
-
-		return startsWith(normalized[len(prefix):], ":")
-	})
+	return declarationIndex(lines, "define "+relation, normalizeSpaces)
 }
 
 type StartEnd struct {

--- a/pkg/go/utils/line-numbers_test.go
+++ b/pkg/go/utils/line-numbers_test.go
@@ -2,6 +2,32 @@ package utils
 
 import "testing"
 
+func TestIsNameByte(t *testing.T) {
+	t.Parallel()
+
+	// IDENTIFIER: (LETTER | '_') (LETTER | DIGIT | '_' | MINUS)*, and
+	// EXTENDED_IDENTIFIER adds SLASH and DOT (OpenFGALexer.g4), so the name bytes
+	// are exactly the ASCII letters, digits, `_`, `-`, `/` and `.`. Checking every
+	// byte pins the table to those ranges, so a mistyped entry cannot survive.
+	isName := func(b byte) bool {
+		switch {
+		case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+			return true
+		case b == '_', b == '-', b == '/', b == '.':
+			return true
+		}
+
+		return false
+	}
+
+	for i := range 256 {
+		b := byte(i)
+		if got, want := IsNameByte(b), isName(b); got != want {
+			t.Errorf("IsNameByte(0x%02X) = %v, want %v", b, got, want)
+		}
+	}
+}
+
 func TestGetTypeLineNumber(t *testing.T) {
 	t.Parallel()
 
@@ -52,6 +78,12 @@ func TestGetTypeLineNumber(t *testing.T) {
 			name:     "does not match a hyphenated name that extends the one asked for",
 			typeName: "my-doc",
 			lines:    []string{"type my-doc-archive", "type my-doc"},
+			want:     1,
+		},
+		{
+			name:     "does not match a slashed name that extends the one asked for",
+			typeName: "internal",
+			lines:    []string{"type internal/doc", "type internal"},
 			want:     1,
 		},
 		{

--- a/pkg/go/utils/line-numbers_test.go
+++ b/pkg/go/utils/line-numbers_test.go
@@ -28,6 +28,35 @@ func TestIsNameByte(t *testing.T) {
 	}
 }
 
+func TestNormalizeWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already normal returns unchanged", in: "define owner: [user]", want: "define owner: [user]"},
+		{name: "collapses repeated spaces", in: "define  owner:", want: "define owner:"},
+		{name: "folds a tab", in: "define\towner:", want: "define owner:"},
+		{name: "folds a form feed", in: "define\fowner:", want: "define owner:"},
+		{name: "folds a mixed run", in: "extend \t type\f\forg", want: "extend type org"},
+		{name: "folds leading and trailing runs", in: "\t define owner \f", want: " define owner "},
+		{name: "leaves other bytes alone", in: "a\vb", want: "a\vb"},
+		{name: "empty line", in: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeWhitespace(tt.in); got != tt.want {
+				t.Errorf("NormalizeWhitespace(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetTypeLineNumber(t *testing.T) {
 	t.Parallel()
 
@@ -101,6 +130,26 @@ func TestGetTypeLineNumber(t *testing.T) {
 			want:     1,
 		},
 		{
+			// WHITESPACE is ('\t' | ' ' | '\u000C')+, so any of the three can
+			// separate `type` from the name.
+			name:     "allows a tab between type and the name",
+			typeName: "user",
+			lines:    []string{"model", "type\tuser"},
+			want:     1,
+		},
+		{
+			name:     "allows a form feed between type and the name",
+			typeName: "user",
+			lines:    []string{"model", "type\fuser"},
+			want:     1,
+		},
+		{
+			name:     "collapses a mixed run of whitespace between type and the name",
+			typeName: "user",
+			lines:    []string{"model", "type \t user"},
+			want:     1,
+		},
+		{
 			name:     "returns -1 when absent",
 			typeName: "missing",
 			lines:    []string{"type user", "type org"},
@@ -157,6 +206,12 @@ func TestGetExtendedTypeLineNumber(t *testing.T) {
 			typeName: "org",
 			lines:    []string{"extend type org\f# module: org, file: org.fga"},
 			want:     0,
+		},
+		{
+			name:     "allows tabs between extend, type and the name",
+			typeName: "org",
+			lines:    []string{"type org", "extend\ttype\torg"},
+			want:     1,
 		},
 		{
 			name:     "returns -1 when absent",
@@ -218,6 +273,26 @@ func TestGetRelationLineNumber(t *testing.T) {
 			want:     0,
 		},
 		{
+			// `define\towner: [user]` parses — WHITESPACE admits tabs — so the
+			// definition must be findable.
+			name:     "allows a tab between define and the name",
+			relation: "owner",
+			lines:    []string{"    define\towner: [user]"},
+			want:     0,
+		},
+		{
+			name:     "allows a form feed between define and the name",
+			relation: "owner",
+			lines:    []string{"    define\fowner: [user]"},
+			want:     0,
+		},
+		{
+			name:     "collapses a mixed run of whitespace between define and the name",
+			relation: "owner",
+			lines:    []string{"    define \t owner: [user]"},
+			want:     0,
+		},
+		{
 			name:     "returns -1 when absent",
 			relation: "missing",
 			lines:    []string{"    define owner: [user]"},
@@ -274,6 +349,18 @@ func TestGetConditionLineNumber(t *testing.T) {
 			name:          "allows a form feed before the parameter list",
 			conditionName: "less",
 			lines:         []string{"condition less\f(x: int) {"},
+			want:          0,
+		},
+		{
+			name:          "allows a tab between condition and the name",
+			conditionName: "less",
+			lines:         []string{"condition\tless(x: int) {"},
+			want:          0,
+		},
+		{
+			name:          "collapses a mixed run of whitespace between condition and the name",
+			conditionName: "less",
+			lines:         []string{"condition \t less(x: int) {"},
 			want:          0,
 		},
 		{

--- a/pkg/go/utils/line-numbers_test.go
+++ b/pkg/go/utils/line-numbers_test.go
@@ -42,6 +42,14 @@ func TestGetTypeLineNumber(t *testing.T) {
 			want:     1,
 		},
 		{
+			// WHITESPACE admits \f, so it must separate a name from its trailing
+			// comment as a space would; trimming only " \t" collapsed this to 0:0.
+			name:     "allows a form feed before a trailing comment",
+			typeName: "other",
+			lines:    []string{"type user", "type other\f# module: core, file: core.fga"},
+			want:     1,
+		},
+		{
 			name:     "returns -1 when absent",
 			typeName: "missing",
 			lines:    []string{"type user", "type org"},
@@ -91,6 +99,12 @@ func TestGetExtendedTypeLineNumber(t *testing.T) {
 			name:     "allows a trailing module comment",
 			typeName: "org",
 			lines:    []string{"extend type org # module: org, file: org.fga"},
+			want:     0,
+		},
+		{
+			name:     "allows a form feed before a trailing comment",
+			typeName: "org",
+			lines:    []string{"extend type org\f# module: org, file: org.fga"},
 			want:     0,
 		},
 		{
@@ -146,6 +160,13 @@ func TestGetRelationLineNumber(t *testing.T) {
 			want:     0,
 		},
 		{
+			// `define owner\f: [user]` parses, so it must be findable.
+			name:     "allows a form feed before the colon",
+			relation: "owner",
+			lines:    []string{"    define owner\f: [user]"},
+			want:     0,
+		},
+		{
 			name:     "returns -1 when absent",
 			relation: "missing",
 			lines:    []string{"    define owner: [user]"},
@@ -195,6 +216,13 @@ func TestGetConditionLineNumber(t *testing.T) {
 			name:          "allows whitespace before the parameter list",
 			conditionName: "less",
 			lines:         []string{"condition less (x: int) {"},
+			want:          0,
+		},
+		{
+			// `condition less\f(x: int) {` parses, so it must be findable.
+			name:          "allows a form feed before the parameter list",
+			conditionName: "less",
+			lines:         []string{"condition less\f(x: int) {"},
 			want:          0,
 		},
 		{

--- a/pkg/go/utils/line-numbers_test.go
+++ b/pkg/go/utils/line-numbers_test.go
@@ -30,9 +30,28 @@ func TestGetTypeLineNumber(t *testing.T) {
 			want:     1,
 		},
 		{
-			name:     "does not treat a glued hash as a comment",
+			// `#`, `/`, `.` and `-` are all name bytes or name terminators per the
+			// grammar's identifier rules; `#` terminates, so this resolves to the
+			// first line. `type doc#x` is not valid DSL, so it cannot reach here
+			// from a parsed model — the case is pinned only to document the choice.
+			name:     "treats a glued hash as ending the name",
 			typeName: "doc",
 			lines:    []string{"type doc#x", "type doc"},
+			want:     0,
+		},
+		{
+			// EXTENDED_IDENTIFIER admits `.`, `/` and `-` inside a name, so a
+			// module-qualified name must not match a longer one that shares its
+			// prefix.
+			name:     "does not match a dotted name that extends the one asked for",
+			typeName: "core.doc",
+			lines:    []string{"type core.doc2", "type core.doc"},
+			want:     1,
+		},
+		{
+			name:     "does not match a hyphenated name that extends the one asked for",
+			typeName: "my-doc",
+			lines:    []string{"type my-doc-archive", "type my-doc"},
 			want:     1,
 		},
 		{

--- a/pkg/go/utils/line-numbers_test.go
+++ b/pkg/go/utils/line-numbers_test.go
@@ -1,0 +1,223 @@
+package utils
+
+import "testing"
+
+func TestGetTypeLineNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		typeName string
+		lines    []string
+		want     int
+	}{
+		{
+			name:     "finds the declaration",
+			typeName: "user",
+			lines:    []string{"model", "  schema 1.2", "type user", "  relations"},
+			want:     2,
+		},
+		{
+			name:     "does not match a type whose name extends the one asked for",
+			typeName: "document",
+			lines:    []string{"type documentation", "  relations", "type document", "  relations"},
+			want:     2,
+		},
+		{
+			name:     "allows a trailing module comment",
+			typeName: "other",
+			lines:    []string{"type user", "type other # module: core, file: core.fga"},
+			want:     1,
+		},
+		{
+			name:     "does not treat a glued hash as a comment",
+			typeName: "doc",
+			lines:    []string{"type doc#x", "type doc"},
+			want:     1,
+		},
+		{
+			name:     "does not match an extend declaration",
+			typeName: "user",
+			lines:    []string{"extend type user", "type user"},
+			want:     1,
+		},
+		{
+			name:     "returns -1 when absent",
+			typeName: "missing",
+			lines:    []string{"type user", "type org"},
+			want:     -1,
+		},
+		{
+			name:     "returns -1 for no lines",
+			typeName: "user",
+			lines:    nil,
+			want:     -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GetTypeLineNumber(tt.typeName, tt.lines); got != tt.want {
+				t.Errorf("GetTypeLineNumber(%q) = %d, want %d", tt.typeName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetExtendedTypeLineNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		typeName string
+		lines    []string
+		want     int
+	}{
+		{
+			name:     "finds the extend declaration",
+			typeName: "user",
+			lines:    []string{"type user", "extend type user", "  relations"},
+			want:     1,
+		},
+		{
+			name:     "does not match a type whose name extends the one asked for",
+			typeName: "document",
+			lines:    []string{"extend type documentation", "extend type document"},
+			want:     1,
+		},
+		{
+			name:     "allows a trailing module comment",
+			typeName: "org",
+			lines:    []string{"extend type org # module: org, file: org.fga"},
+			want:     0,
+		},
+		{
+			name:     "returns -1 when absent",
+			typeName: "user",
+			lines:    []string{"type user"},
+			want:     -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GetExtendedTypeLineNumber(tt.typeName, tt.lines); got != tt.want {
+				t.Errorf("GetExtendedTypeLineNumber(%q) = %d, want %d", tt.typeName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRelationLineNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		relation string
+		lines    []string
+		want     int
+	}{
+		{
+			name:     "finds the definition",
+			relation: "owner",
+			lines:    []string{"type doc", "  relations", "    define owner: [user]"},
+			want:     2,
+		},
+		{
+			name:     "does not match a relation whose name extends the one asked for",
+			relation: "owner",
+			lines:    []string{"    define owner_group: [group]", "    define owner: [user]"},
+			want:     1,
+		},
+		{
+			name:     "tolerates repeated spaces after define",
+			relation: "owner",
+			lines:    []string{"    define  owner: [user]"},
+			want:     0,
+		},
+		{
+			name:     "allows whitespace before the colon",
+			relation: "owner",
+			lines:    []string{"    define owner : [user]"},
+			want:     0,
+		},
+		{
+			name:     "returns -1 when absent",
+			relation: "missing",
+			lines:    []string{"    define owner: [user]"},
+			want:     -1,
+		},
+		{
+			name:     "returns -1 for no lines",
+			relation: "owner",
+			lines:    nil,
+			want:     -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GetRelationLineNumber(tt.relation, tt.lines); got != tt.want {
+				t.Errorf("GetRelationLineNumber(%q) = %d, want %d", tt.relation, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConditionLineNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		conditionName string
+		lines         []string
+		want          int
+	}{
+		{
+			name:          "finds the declaration",
+			conditionName: "in_range",
+			lines:         []string{"type user", "condition in_range(x: int) {"},
+			want:          1,
+		},
+		{
+			name:          "does not match a condition whose name extends the one asked for",
+			conditionName: "less",
+			lines:         []string{"condition less_than(x: int) {", "condition less(x: int) {"},
+			want:          1,
+		},
+		{
+			name:          "allows whitespace before the parameter list",
+			conditionName: "less",
+			lines:         []string{"condition less (x: int) {"},
+			want:          0,
+		},
+		{
+			name:          "returns -1 when absent",
+			conditionName: "missing",
+			lines:         []string{"condition less(x: int) {"},
+			want:          -1,
+		},
+		{
+			name:          "returns -1 for no lines",
+			conditionName: "less",
+			lines:         nil,
+			want:          -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := GetConditionLineNumber(tt.conditionName, tt.lines); got != tt.want {
+				t.Errorf("GetConditionLineNumber(%q) = %d, want %d", tt.conditionName, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/go/validation/name_validation.go
+++ b/pkg/go/validation/name_validation.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/language/pkg/go/utils"
 )
 
 // ValidationRegexRules contains the regex rules for validation
@@ -176,18 +178,15 @@ func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int
 
 	conditionPrefix := "condition " + conditionName
 	for i := start; i < len(lines); i++ {
-		// Match the condition declaration itself, mirroring the reference's
-		// `condition <name>` prefix check, so we don't match an unrelated line
-		// that merely contains the condition name as a substring. The parameter
-		// list's `(` must follow the name so a condition whose name is a prefix
-		// of another (e.g. `less` vs `less_than`) cannot match the wrong line.
+		// The name must end at the prefix, so `less` does not match a declaration
+		// of `less_than`.
 		trimmedLine := strings.TrimSpace(lines[i])
 		if !strings.HasPrefix(trimmedLine, conditionPrefix) {
 			continue
 		}
-		// The cutset must match the grammar's WHITESPACE token, which admits `\f`
-		// as well as spaces and tabs; see utils.intraLineWhitespace.
-		if strings.HasPrefix(strings.TrimLeft(trimmedLine[len(conditionPrefix):], " \t\f"), "(") {
+
+		rest := trimmedLine[len(conditionPrefix):]
+		if rest == "" || !utils.IsNameByte(rest[0]) {
 			return &i
 		}
 	}

--- a/pkg/go/validation/name_validation.go
+++ b/pkg/go/validation/name_validation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openfga/language/pkg/go/utils"
 )
 
+// ValidationRegexRules contains the regex rules for validation.
 // These match the Rules from the JS implementation.
 var ValidationRegexRules = struct {
 	Type      string
@@ -25,7 +26,8 @@ var ValidationRegexRules = struct {
 	Object:    "[^\\s]{2,256}",
 }
 
-// them once. CompiledNameRules caches them by their anchored rule string, which
+// The anchored type, relation, and condition name rules are fixed, so compile
+// them once. compiledNameRules caches them by their anchored rule string, which
 // is also the clause reported in the error, so validateFieldValue can look up
 // the compiled pattern without recompiling on every name.
 var (
@@ -40,7 +42,8 @@ var (
 	}
 )
 
-// This enhances the basic regex validation with semantic checks.
+// ValidateTypeName validates a type name with both regex and reserved keyword
+// checking. This enhances the basic regex validation with semantic checks.
 func ValidateTypeName(typeName string, collector *ErrorCollector, lineIndex *int, meta *Meta) bool {
 	// First check if it's a reserved keyword
 	if IsReservedTypeName(typeName) {
@@ -58,7 +61,8 @@ func ValidateTypeName(typeName string, collector *ErrorCollector, lineIndex *int
 	return true
 }
 
-// This enhances the basic regex validation with semantic checks.
+// ValidateRelationName validates a relation name with both regex and reserved
+// keyword checking. This enhances the basic regex validation with semantic checks.
 func ValidateRelationName(relationName, typeName string, collector *ErrorCollector, lineIndex *int, meta *Meta) bool {
 	// First check if it's a reserved keyword
 	if IsReservedRelationName(relationName) {
@@ -99,6 +103,7 @@ func validateFieldValue(rule, value string) bool {
 	return regex.MatchString(value)
 }
 
+// GetTypeLineNumber finds the line number where a type is defined.
 // This is equivalent to the getTypeLineNumber function in JS.
 func GetTypeLineNumber(typeName string, lines []string, skipIndex *int) *int {
 	if len(lines) == 0 {
@@ -125,7 +130,8 @@ func GetTypeLineNumber(typeName string, lines []string, skipIndex *int) *int {
 	return nil
 }
 
-// SkipIndex, when provided, is the index to begin searching from (inclusive) —
+// GetRelationLineNumber finds the line number where a relation is defined.
+// skipIndex, when provided, is the index to begin searching from (inclusive) —
 // matching the reference implementation's getRelationLineNumber, which slices
 // the lines from skipIndex onward. This lets callers anchor the search to a
 // specific type block so the correct occurrence is found when several types
@@ -160,6 +166,7 @@ func GetRelationLineNumber(relationName string, lines []string, skipIndex *int) 
 	return nil
 }
 
+// GetConditionLineNumber finds the line number where a condition is defined.
 // This is equivalent to the geConditionLineNumber function in JS.
 func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int) *int {
 	if len(lines) == 0 {
@@ -190,6 +197,7 @@ func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int
 	return nil
 }
 
+// ValidateNameRules validates naming rules for types and relations in a model.
 // This is equivalent to the populateRelations function's naming validation in JS.
 func ValidateNameRules(collector *ErrorCollector, typeName string, relationNames []string,
 	typeLineIndex *int, meta *Meta, lines []string) {

--- a/pkg/go/validation/name_validation.go
+++ b/pkg/go/validation/name_validation.go
@@ -185,7 +185,9 @@ func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int
 		if !strings.HasPrefix(trimmedLine, conditionPrefix) {
 			continue
 		}
-		if strings.HasPrefix(strings.TrimLeft(trimmedLine[len(conditionPrefix):], " \t"), "(") {
+		// The cutset must match the grammar's WHITESPACE token, which admits `\f`
+		// as well as spaces and tabs; see utils.intraLineWhitespace.
+		if strings.HasPrefix(strings.TrimLeft(trimmedLine[len(conditionPrefix):], " \t\f"), "(") {
 			return &i
 		}
 	}

--- a/pkg/go/validation/name_validation.go
+++ b/pkg/go/validation/name_validation.go
@@ -10,8 +10,7 @@ import (
 	"github.com/openfga/language/pkg/go/utils"
 )
 
-// ValidationRegexRules contains the regex rules for validation
-// These match the Rules from the JS implementation
+// These match the Rules from the JS implementation.
 var ValidationRegexRules = struct {
 	Type      string
 	Relation  string
@@ -26,8 +25,7 @@ var ValidationRegexRules = struct {
 	Object:    "[^\\s]{2,256}",
 }
 
-// The anchored type, relation, and condition name rules are fixed, so compile
-// them once. compiledNameRules caches them by their anchored rule string, which
+// them once. CompiledNameRules caches them by their anchored rule string, which
 // is also the clause reported in the error, so validateFieldValue can look up
 // the compiled pattern without recompiling on every name.
 var (
@@ -42,8 +40,7 @@ var (
 	}
 )
 
-// ValidateTypeName validates a type name with both regex and reserved keyword checking
-// This enhances the basic regex validation with semantic checks
+// This enhances the basic regex validation with semantic checks.
 func ValidateTypeName(typeName string, collector *ErrorCollector, lineIndex *int, meta *Meta) bool {
 	// First check if it's a reserved keyword
 	if IsReservedTypeName(typeName) {
@@ -61,8 +58,7 @@ func ValidateTypeName(typeName string, collector *ErrorCollector, lineIndex *int
 	return true
 }
 
-// ValidateRelationName validates a relation name with both regex and reserved keyword checking
-// This enhances the basic regex validation with semantic checks
+// This enhances the basic regex validation with semantic checks.
 func ValidateRelationName(relationName, typeName string, collector *ErrorCollector, lineIndex *int, meta *Meta) bool {
 	// First check if it's a reserved keyword
 	if IsReservedRelationName(relationName) {
@@ -103,8 +99,7 @@ func validateFieldValue(rule, value string) bool {
 	return regex.MatchString(value)
 }
 
-// GetTypeLineNumber finds the line number where a type is defined
-// This is equivalent to the getTypeLineNumber function in JS
+// This is equivalent to the getTypeLineNumber function in JS.
 func GetTypeLineNumber(typeName string, lines []string, skipIndex *int) *int {
 	if len(lines) == 0 {
 		return nil
@@ -116,8 +111,9 @@ func GetTypeLineNumber(typeName string, lines []string, skipIndex *int) *int {
 			continue
 		}
 
-		// Look for "type typeName" pattern
-		trimmedLine := strings.TrimSpace(line)
+		// Look for "type typeName" pattern. Runs of inline whitespace are folded
+		// first so `type\tuser` passes the "type " prefix gate like `type user`.
+		trimmedLine := utils.NormalizeWhitespace(strings.TrimSpace(line))
 		if strings.HasPrefix(trimmedLine, "type ") {
 			parts := strings.Fields(trimmedLine)
 			if len(parts) >= 2 && parts[1] == typeName {
@@ -129,8 +125,7 @@ func GetTypeLineNumber(typeName string, lines []string, skipIndex *int) *int {
 	return nil
 }
 
-// GetRelationLineNumber finds the line number where a relation is defined.
-// skipIndex, when provided, is the index to begin searching from (inclusive) —
+// SkipIndex, when provided, is the index to begin searching from (inclusive) —
 // matching the reference implementation's getRelationLineNumber, which slices
 // the lines from skipIndex onward. This lets callers anchor the search to a
 // specific type block so the correct occurrence is found when several types
@@ -146,8 +141,9 @@ func GetRelationLineNumber(relationName string, lines []string, skipIndex *int) 
 	}
 
 	for i := start; i < len(lines); i++ {
-		// Look for "define relationName:" pattern
-		trimmedLine := strings.TrimSpace(lines[i])
+		// Look for "define relationName:" pattern. Runs of inline whitespace are
+		// folded first so `define\towner:` is found like `define owner:`.
+		trimmedLine := utils.NormalizeWhitespace(strings.TrimSpace(lines[i]))
 		if strings.HasPrefix(trimmedLine, "define ") {
 			// Extract relation name from "define relationName:"
 			definePart := strings.TrimPrefix(trimmedLine, "define ")
@@ -164,8 +160,7 @@ func GetRelationLineNumber(relationName string, lines []string, skipIndex *int) 
 	return nil
 }
 
-// GetConditionLineNumber finds the line number where a condition is defined
-// This is equivalent to the geConditionLineNumber function in JS
+// This is equivalent to the geConditionLineNumber function in JS.
 func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int) *int {
 	if len(lines) == 0 {
 		return nil
@@ -179,8 +174,9 @@ func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int
 	conditionPrefix := "condition " + conditionName
 	for i := start; i < len(lines); i++ {
 		// The name must end at the prefix, so `less` does not match a declaration
-		// of `less_than`.
-		trimmedLine := strings.TrimSpace(lines[i])
+		// of `less_than`. Inline whitespace is folded first so `condition\tless(`
+		// is found like `condition less(`.
+		trimmedLine := utils.NormalizeWhitespace(strings.TrimSpace(lines[i]))
 		if !strings.HasPrefix(trimmedLine, conditionPrefix) {
 			continue
 		}
@@ -194,8 +190,7 @@ func GetConditionLineNumber(conditionName string, lines []string, skipIndex *int
 	return nil
 }
 
-// ValidateNameRules validates naming rules for types and relations in a model
-// This is equivalent to the populateRelations function's naming validation in JS
+// This is equivalent to the populateRelations function's naming validation in JS.
 func ValidateNameRules(collector *ErrorCollector, typeName string, relationNames []string,
 	typeLineIndex *int, meta *Meta, lines []string) {
 	// Validate type name

--- a/pkg/go/validation/name_validation_test.go
+++ b/pkg/go/validation/name_validation_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestValidationRegexRules(t *testing.T) {
 	// Test that regex rules match the JS implementation
 	assert.Equal(t, "[^:#@\\*\\s]{1,254}", ValidationRegexRules.Type)
@@ -342,6 +341,17 @@ func TestGetTypeLineNumber(t *testing.T) {
 			expected:  ptrInt(2),
 		},
 		{
+			// Tabs are folded before the `type ` prefix gate, so a tab after
+			// `type` works.
+			name:     "finds type separated by a tab",
+			typeName: "user",
+			lines: []string{
+				"model",
+				"type\tuser",
+			},
+			expected: ptrInt(1),
+		},
+		{
 			name:     "empty lines",
 			typeName: "document",
 			lines:    []string{},
@@ -422,6 +432,28 @@ func TestGetRelationLineNumber(t *testing.T) {
 			expected:  ptrInt(2),
 		},
 		{
+			// WHITESPACE is ('\t' | ' ' | '\u000C')+, so `define\tviewer:` parses
+			// and must be findable.
+			name:         "finds relation separated by a tab",
+			relationName: "viewer",
+			lines: []string{
+				"type document",
+				"  relations",
+				"    define\tviewer: [user]",
+			},
+			expected: ptrInt(2),
+		},
+		{
+			name:         "finds relation separated by a mixed whitespace run",
+			relationName: "viewer",
+			lines: []string{
+				"type document",
+				"  relations",
+				"    define \t viewer: [user]",
+			},
+			expected: ptrInt(2),
+		},
+		{
 			name:         "empty lines",
 			relationName: "viewer",
 			lines:        []string{},
@@ -488,6 +520,15 @@ func TestGetConditionLineNumber(t *testing.T) {
 			// skipIndex is a start offset: from index 1 the next declaration is at 2.
 			skipIndex: ptrInt(1),
 			expected:  ptrInt(2),
+		},
+		{
+			name:          "finds condition separated by a tab",
+			conditionName: "is_owner",
+			lines: []string{
+				"type document",
+				"condition\tis_owner(x: int) {",
+			},
+			expected: ptrInt(1),
 		},
 		{
 			name:          "empty lines",

--- a/pkg/go/validation/schema_validation.go
+++ b/pkg/go/validation/schema_validation.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/language/pkg/go/utils"
 )
 
 const (
@@ -17,10 +19,6 @@ var SupportedSchemaVersions = map[string]bool{
 	SchemaVersion12: true,
 }
 
-// multiSpaceRegex collapses runs of whitespace when normalizing a DSL line for
-// schema-version matching. Hoisted so it is compiled once, not per line.
-var multiSpaceRegex = regexp.MustCompile(`\s{2,}`)
-
 func IsValidSchemaVersion(version string) bool {
 	return SupportedSchemaVersions[version]
 }
@@ -29,11 +27,14 @@ func GetSchemaLineNumber(schemaVersion string, lines []string) *int {
 	if len(lines) == 0 {
 		return nil
 	}
-	pattern := `^\s*schema\s+` + regexp.QuoteMeta(schemaVersion) + `\s*$`
+	// A trailing comment may follow the version (`schema 1.5 # note`), matching the
+	// reference's `(\s+#.*)?`.
+	pattern := `^\s*schema\s+` + regexp.QuoteMeta(schemaVersion) + `(\s+#.*)?$`
 	regex := regexp.MustCompile(pattern)
 	for i, line := range lines {
-		normalizedLine := strings.TrimSpace(line)
-		normalizedLine = multiSpaceRegex.ReplaceAllString(normalizedLine, " ")
+		// Fold inline whitespace with the helper the other line-number lookups
+		// use, so `schema\t1.5` resolves like `schema 1.5`.
+		normalizedLine := utils.NormalizeWhitespace(strings.TrimSpace(line))
 		if regex.MatchString(normalizedLine) {
 			return &i
 		}

--- a/pkg/go/validation/yaml_test_integration_test.go
+++ b/pkg/go/validation/yaml_test_integration_test.go
@@ -235,16 +235,17 @@ func (runner *YAMLTestRunner) errorsMatch(expected YAMLExpectedError, actual *Va
 		}
 	}
 	
-	// Check line numbers if specified
-	if expected.Line.Start > 0 && actual.Line != nil {
-		if actual.Line.Start != expected.Line.Start {
+	// Check line numbers if specified. A case that pins a line requires the error
+	// to carry one, so an error with no position at all is a mismatch.
+	if expected.Line.Start > 0 {
+		if actual.Line == nil || actual.Line.Start != expected.Line.Start {
 			return false
 		}
 	}
 	
 	// Check column numbers if specified
-	if expected.Column.Start > 0 && actual.Column != nil {
-		if actual.Column.Start != expected.Column.Start {
+	if expected.Column.Start > 0 {
+		if actual.Column == nil || actual.Column.Start != expected.Column.Start {
 			return false
 		}
 	}

--- a/pkg/java/src/main/java/dev/openfga/language/validation/Dsl.java
+++ b/pkg/java/src/main/java/dev/openfga/language/validation/Dsl.java
@@ -31,6 +31,14 @@ class Dsl {
                 .orElse(-1);
     }
 
+    // Collapse every run of inline whitespace into one space — space, tab and form
+    // feed are exactly what the lexer's WHITESPACE rule admits between tokens
+    // (OpenFGALexer.g4), so `define\towner:` must be found like `define owner:`.
+    // Anything else (nbsp, vertical tab) fails to lex and can never reach a lookup.
+    private static String normalizeWhitespace(String line) {
+        return line.trim().replaceAll("[ \\t\\f]+", " ");
+    }
+
     public int getConditionLineNumber(String conditionName) {
         return getConditionLineNumber(conditionName, 0);
     }
@@ -39,16 +47,15 @@ class Dsl {
         // Require `(` after the name so a condition name that is a prefix of
         // another (e.g. `less` vs `less_than`) cannot match the wrong line.
         return findLine(
-                line -> line.trim().matches("condition " + Pattern.quote(conditionName) + "\\s*\\(.*"), skipIndex);
+                line -> normalizeWhitespace(line).matches("condition " + Pattern.quote(conditionName) + "\\s*\\(.*"),
+                skipIndex);
     }
 
     public int getRelationLineNumber(String relationName, int skipIndex) {
         // Require `:` after the name so a relation name that is a prefix of
         // another (e.g. `writer` vs `writers`) cannot match the wrong line.
         return findLine(
-                line -> line.trim()
-                        .replaceAll(" {2,}", " ")
-                        .matches("define " + Pattern.quote(relationName) + "\\s*:.*"),
+                line -> normalizeWhitespace(line).matches("define " + Pattern.quote(relationName) + "\\s*:.*"),
                 skipIndex);
     }
 
@@ -57,10 +64,7 @@ class Dsl {
         // e.g. `1.1` cannot match `schema 1.10`. A comment must be preceded by
         // whitespace so a `#` glued to the version isn't treated as a comment.
         return findLine(
-                line -> line.trim()
-                        .replaceAll(" {2,}", " ")
-                        .matches("schema " + Pattern.quote(schemaVersion) + "(\\s+#.*)?"),
-                0);
+                line -> normalizeWhitespace(line).matches("schema " + Pattern.quote(schemaVersion) + "(\\s+#.*)?"), 0);
     }
 
     public int getTypeLineNumber(String typeName) {
@@ -71,7 +75,8 @@ class Dsl {
         // Allow an optional trailing comment (e.g. `type page # module: ...`) after the type name.
         // The comment must be preceded by whitespace so a `#` glued to the name isn't treated as a comment.
         // Quote the type name so regex metacharacters (e.g. `.`) are matched literally.
-        return findLine(line -> line.trim().matches("type " + Pattern.quote(typeName) + "(\\s+#.*)?"), skipIndex);
+        return findLine(
+                line -> normalizeWhitespace(line).matches("type " + Pattern.quote(typeName) + "(\\s+#.*)?"), skipIndex);
     }
 
     public static String getRelationDefName(Userset userset) {

--- a/pkg/js/util/line-numbers.ts
+++ b/pkg/js/util/line-numbers.ts
@@ -1,3 +1,9 @@
+// Collapse every run of inline whitespace into one space — space, tab and form
+// feed are exactly what the lexer's WHITESPACE rule admits between tokens
+// (OpenFGALexer.g4), so `define\towner:` must be found like `define owner:`.
+// Anything else (nbsp, vertical tab) fails to lex and can never reach a lookup.
+const normalizeWhitespace = (line: string) => line.trim().replace(/[ \t\f]+/g, " ");
+
 export const getConditionLineNumber = (conditionName: string, lines?: string[], skipIndex?: number) => {
   if (!skipIndex || skipIndex < 0) {
     skipIndex = 0;
@@ -9,8 +15,8 @@ export const getConditionLineNumber = (conditionName: string, lines?: string[], 
   // (e.g. `less` vs `less_than`) cannot match the wrong line.
   const conditionPrefix = `condition ${conditionName}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const trimmed = line.trim();
-    return trimmed.startsWith(conditionPrefix) && /^\s*\(/.test(trimmed.slice(conditionPrefix.length));
+    const normalized = normalizeWhitespace(line);
+    return normalized.startsWith(conditionPrefix) && /^\s*\(/.test(normalized.slice(conditionPrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;
 };
@@ -27,8 +33,8 @@ export const getTypeLineNumber = (typeName: string, lines?: string[], skipIndex?
   // Match the type name literally (it may contain regex metacharacters like `.`).
   const typePrefix = `${extension ? "extend " : ""}type ${typeName}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const trimmed = line.trim();
-    return trimmed.startsWith(typePrefix) && /^(\s+#.*)?$/.test(trimmed.slice(typePrefix.length));
+    const normalized = normalizeWhitespace(line);
+    return normalized.startsWith(typePrefix) && /^(\s+#.*)?$/.test(normalized.slice(typePrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;
 };
@@ -43,7 +49,7 @@ export const getRelationLineNumber = (relation: string, lines?: string[], skipIn
   // Match the relation name literally (it may contain regex metacharacters like `.`).
   const relationPrefix = `define ${relation}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const normalized = line.trim().replace(/ {2,}/g, " ");
+    const normalized = normalizeWhitespace(line);
     return normalized.startsWith(relationPrefix) && /^\s*:/.test(normalized.slice(relationPrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;

--- a/pkg/js/validator/validate-dsl.ts
+++ b/pkg/js/validator/validate-dsl.ts
@@ -291,6 +291,12 @@ function hasEntryPointOrLoop(
   return { hasEntry: false, loop: false };
 }
 
+// Collapse every run of inline whitespace into one space — space, tab and form
+// feed are exactly what the lexer's WHITESPACE rule admits between tokens
+// (OpenFGALexer.g4), so `define\towner:` must be found like `define owner:`.
+// Anything else (nbsp, vertical tab) fails to lex and can never reach a lookup.
+const normalizeWhitespace = (line: string) => line.trim().replace(/[ \t\f]+/g, " ");
+
 const geConditionLineNumber = (conditionName: string, lines?: string[], skipIndex?: number) => {
   if (!skipIndex || skipIndex < 0) {
     skipIndex = 0;
@@ -302,8 +308,8 @@ const geConditionLineNumber = (conditionName: string, lines?: string[], skipInde
   // (e.g. `less` vs `less_than`) cannot match the wrong line.
   const conditionPrefix = `condition ${conditionName}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const trimmed = line.trim();
-    return trimmed.startsWith(conditionPrefix) && /^\s*\(/.test(trimmed.slice(conditionPrefix.length));
+    const normalized = normalizeWhitespace(line);
+    return normalized.startsWith(conditionPrefix) && /^\s*\(/.test(normalized.slice(conditionPrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;
 };
@@ -320,8 +326,8 @@ const getTypeLineNumber = (typeName: string, lines?: string[], skipIndex?: numbe
   // Match the type name literally (it may contain regex metacharacters like `.`).
   const typePrefix = `type ${typeName}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const trimmed = line.trim();
-    return trimmed.startsWith(typePrefix) && /^(\s+#.*)?$/.test(trimmed.slice(typePrefix.length));
+    const normalized = normalizeWhitespace(line);
+    return normalized.startsWith(typePrefix) && /^(\s+#.*)?$/.test(normalized.slice(typePrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;
 };
@@ -336,7 +342,7 @@ const getRelationLineNumber = (relation: string, lines?: string[], skipIndex?: n
   // Match the relation name literally (it may contain regex metacharacters like `.`).
   const relationPrefix = `define ${relation}`;
   const index = lines.slice(skipIndex).findIndex((line: string) => {
-    const normalized = line.trim().replace(/ {2,}/g, " ");
+    const normalized = normalizeWhitespace(line);
     return normalized.startsWith(relationPrefix) && /^\s*:/.test(normalized.slice(relationPrefix.length));
   });
   return index === -1 ? -1 : index + skipIndex;
@@ -352,7 +358,7 @@ const getSchemaLineNumber = (schema: string, lines?: string[]) => {
   // Match the schema version literally (it contains `.`).
   const schemaPrefix = `schema ${schema}`;
   const index = lines.slice(0).findIndex((line: string) => {
-    const normalized = line.trim().replace(/ {2,}/g, " ");
+    const normalized = normalizeWhitespace(line);
     return normalized.startsWith(schemaPrefix) && /^(\s+#.*)?$/.test(normalized.slice(schemaPrefix.length));
   });
 

--- a/tests/data/dsl-semantic-validation-cases.yaml
+++ b/tests/data/dsl-semantic-validation-cases.yaml
@@ -2275,3 +2275,85 @@
       metadata:
         symbol: "less"
         errorType: condition-not-used
+
+# The four cases below contain literal tab characters (shown as \t in the names)
+# between a declaration keyword and its name. Tabs and form feeds are valid
+# separators per the lexer's WHITESPACE rule, so every SDK must fold them when
+# locating declaration lines. Keep the tabs when editing: replacing them with
+# spaces would stop these cases from guarding that behaviour.
+- name: tab separator in define\treader is folded when locating the error line
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type group
+      relations
+        define	member: [user]
+        define	reader: member but not allowed
+  expected_errors:
+    - msg: "the relation `allowed` does not exist."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 34
+        end: 41
+      metadata:
+        symbol: "allowed"
+        errorType: missing-definition
+- name: tab separator in type\tself is folded when locating the error line
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type	self
+      relations
+        define member: [user]
+  expected_errors:
+    - msg: "a type cannot be named 'self' or 'this'."
+      line:
+        start: 3
+        end: 3
+      column:
+        start: 5
+        end: 9
+      metadata:
+        symbol: "self"
+        errorType: reserved-type-keywords
+- name: tab separator in condition\tallowed_ip is folded when locating the error line
+  dsl: |
+    model
+      schema 1.1
+    type user
+    type document
+      relations
+        define viewer: [user]
+    condition	allowed_ip(current_ip: ipaddress) {
+      current_ip.in_cidr("192.168.0.0/24")
+    }
+  expected_errors:
+    - msg: "`allowed_ip` condition is not used in the model."
+      line:
+        start: 6
+        end: 6
+      column:
+        start: 10
+        end: 20
+      metadata:
+        symbol: "allowed_ip"
+        errorType: condition-not-used
+- name: tab separator in schema\t1.5 is folded when locating the error line
+  dsl: |
+    model
+      schema	1.5
+    type user
+  expected_errors:
+    - msg: "invalid schema 1.5"
+      line:
+        start: 1
+        end: 1
+      column:
+        start: 9
+        end: 12
+      metadata:
+        errorType: invalid-schema

--- a/tests/data/transformer-module/07-prefix-collisions/expected_errors.json
+++ b/tests/data/transformer-module/07-prefix-collisions/expected_errors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "msg": "duplicate condition less",
+    "file": "dup.fga",
+    "line": {
+      "start": 10,
+      "end": 10
+    },
+    "column": {
+      "start": 10,
+      "end": 14
+    }
+  }
+]

--- a/tests/data/transformer-module/07-prefix-collisions/module/core.fga
+++ b/tests/data/transformer-module/07-prefix-collisions/module/core.fga
@@ -1,0 +1,11 @@
+module core
+
+type user
+
+type documentation
+  relations
+    define viewer: [user with less]
+
+condition less(val: int) {
+  val < 5
+}

--- a/tests/data/transformer-module/07-prefix-collisions/module/dup.fga
+++ b/tests/data/transformer-module/07-prefix-collisions/module/dup.fga
@@ -1,0 +1,13 @@
+module dup
+
+type document
+  relations
+    define viewer: [user with less_than]
+
+condition less_than(val: int) {
+  val < 10
+}
+
+condition less(val: int) {
+  val < 3
+}

--- a/tests/data/transformer-module/08-tab-separated-declarations/expected_errors.json
+++ b/tests/data/transformer-module/08-tab-separated-declarations/expected_errors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "msg": "relation owner already exists on type document",
+    "file": "dup.fga",
+    "line": {
+      "start": 4,
+      "end": 4
+    },
+    "column": {
+      "start": 11,
+      "end": 16
+    }
+  }
+]

--- a/tests/data/transformer-module/08-tab-separated-declarations/module/core.fga
+++ b/tests/data/transformer-module/08-tab-separated-declarations/module/core.fga
@@ -1,0 +1,7 @@
+module core
+
+type user
+
+type document
+  relations
+    define owner: [user]

--- a/tests/data/transformer-module/08-tab-separated-declarations/module/dup.fga
+++ b/tests/data/transformer-module/08-tab-separated-declarations/module/dup.fga
@@ -1,0 +1,5 @@
+module dup
+
+extend	type	document
+  relations
+    define	owner: [user]


### PR DESCRIPTION
The line-number helpers in `pkg/go/utils` matched a declaration with `strings.HasPrefix` on the name alone, so a name that is a prefix of another resolved to the wrong line: asking for `document` matched `type documentation`, `owner` matched `define owner_group:`, and `less` matched `condition less_than(`.

## Description

#### What problem is being solved?

`GetTypeLineNumber`, `GetRelationLineNumber`, `GetConditionLineNumber` and `GetExtendedTypeLineNumber` each tested only that a trimmed line started with `"<keyword> <name>"`, with nothing checking what followed the name:

```go
func GetTypeLineNumber(typeName string, lines []string) int {
	return slices.IndexFunc(lines, func(line string) bool {
		return strings.HasPrefix(strings.TrimSpace(line), "type "+typeName)
	})
}
```

Reproduced against `develop` — every one of these returns the line of the longer declaration that happens to come first:

| query | matched | returned | correct |
| --- | --- | --- | --- |
| type `document` | `type documentation` | 2 | 6 |
| relation `owner` | `define owner_group:` | 4 | 5 |
| condition `less` | `condition less_than(` | 7 | 8 |

The helpers have four non-test callers, all in `pkg/go/transformer/module-to-model.go`: the duplicate-type, duplicate-condition, extended-type and duplicate-relation errors. In a module set where one name is a prefix of another, those errors point at the wrong declaration.

This is user-visible in a released package. `pkg/go/utils/line-numbers.go` and `pkg/go/transformer/module-to-model.go` both ship in `pkg/go/v0.3.1`, which is the tag `openfga/cli` pins.

This is the Go half of #255, which listed all three implementations' files. #260 closed it after fixing only the JS and Java copies — `pkg/go/utils/line-numbers.go` was named in the issue but never in the diff, so the Go bug has been live since.

#### How is it being solved?

By requiring the name to *end* where the prefix ends. The four helpers now share one matcher, and the terminator rule is derived from the lexer grammar rather than hand-written per helper:

```go
// IDENTIFIER admits letters, digits, `_` and MINUS; EXTENDED_IDENTIFIER adds
// SLASH and DOT (OpenFGALexer.g4).
func IsNameByte(b byte) bool
```

`declarationIndex` finds the first line starting with the prefix whose next byte is not a name byte (or which ends there). Because the prefix always spans whole words — `type <name>`, `define <name>`, `condition <name>` — that single check is what stops `document` matching `documentation`.

Taking the terminator set from the grammar rather than requiring a specific punctuation character is what makes `type core.doc` a declaration of `core.doc` and not of `core`, since `.` is a name byte in `EXTENDED_IDENTIFIER`. A rule that instead demanded `:` or `(` after the name would get that case wrong.

Only the relation helper collapses runs of spaces, mirroring the reference implementation, where ` {2,}` normalization is applied in `getRelationLineNumber` alone — so `define  owner:` still matches `owner`.

#### What changes are made to solve it?

- `pkg/go/utils/line-numbers.go`: adds `IsNameByte` and the shared `declarationIndex`; the four exported helpers become one-line calls into it. Signatures, the `int` return and the `-1` miss sentinel are all unchanged.
- `pkg/go/validation/name_validation.go`: `GetConditionLineNumber` had its own inline terminator check requiring `(` after the name. It now calls `utils.IsNameByte`, so the rule lives in one place. This is a deliberate loosening — see the note below.
- `tests/data/transformer-module/07-prefix-collisions/`: a module fixture where `documentation`/`document` and `less`/`less_than` collide across two files, asserting the duplicate-condition error lands on `dup.fga` line 10 rather than an earlier `less_than` declaration.
- `pkg/go/utils/line-numbers_test.go`: 47 cases covering each helper, including the trailing-comment form the module fixtures depend on (`type other # module: core, file: core.fga`), collapsed spaces, dotted names, and the three collisions above.

The only visible behaviour change is that the four transformer errors point at the correct line in collision cases. No error identity or message text changes.

#### A note on what this does not tighten

The matcher accepts anything that is not a name byte as a terminator, which is looser than the punctuation each declaration form actually requires. All of these match today:

```
type doc#x            queried as `doc`     -> matches
type doc:x            queried as `doc`     -> matches
define owner [user]   queried as `owner`   -> matches   (no colon)
condition less {      queried as `less`    -> matches   (no parameter list)
```

None of these are valid DSL, and the helpers are only ever called with a name the parser has already accepted from a model that parsed — so a malformed line cannot reach them in practice. Deriving the rule from the grammar was preferred over four hand-written punctuation checks because it is the same rule in every helper and it handles extended identifiers correctly. Worth flagging explicitly rather than leaving it to be discovered.

For the same reason, the two Go copies are now closer but not identical. `pkg/go/validation`'s type and relation helpers parse the line (`strings.Fields`, then an exact compare; or split on `:`), so they reject `type doc#x`, `type doc:x` and `define owner [user]` where `utils` accepts them. Both agree on every well-formed input, including all three collision cases and the trailing-comment form. Unifying the two copies is a follow-up; this PR makes them agree on the cases that occur, not on malformed input.

#### Testing

From `pkg/go`: `go build ./...` clean, and `go test ./... -count=1` green — `utils`, `transformer` and `validation` all pass, with the new module fixture exercised through the transformer path.

The three collisions were verified as failing on `develop` and fixed on this branch by building the helpers standalone against both versions, rather than only through the test suite.

## References

closes https://github.com/openfga/language/issues/255

- #260 — closed #255 after fixing the JS and Java copies only; this is the Go half it missed
- #628 — the JS/Java trailing-comment fix, whose behaviour these helpers are matched against

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
