### PR TITLE
ci: align golangci-lint with CLI

### DIFF
--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -23,8 +24,12 @@ jobs:
       - name: Audit dependencies
         run: make audit-go
 
-      - name: Lint
-        run: make lint-go
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+          working-directory: ./pkg/go
+          args: -v -c .golangci.yaml
 
   check-gen:
     runs-on: ubuntu-latest

--- a/pkg/go/.golangci.yaml
+++ b/pkg/go/.golangci.yaml
@@ -1,76 +1,86 @@
+version: "2"
 run:
-  timeout: 3m
-  modules-download-mode: readonly
-  allow-parallel-runners: true
   build-tags:
     - docker
-
+  modules-download-mode: readonly
+  allow-parallel-runners: true
 linters:
   enable:
+    - bodyclose
     - errname
-    - gofmt
-    - goimports
-    - stylecheck
+    - gocritic
+    - gocyclo
+    - godot
     - importas
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
     - mirror
     - misspell
+    - protogetter
+    - revive
     - staticcheck
     - tagalign
     - testifylint
-    - typecheck
-    - unused
     - unconvert
     - unparam
     - wastedassign
     - whitespace
-    - protogetter
-    - revive
-    - godot
-    - bodyclose
-    - gocritic
-    - gocyclo
-    #- gosec Too many different issues. Needs to be tackled in a separate PR.
-
-linters-settings:
-  gofmt:
-    simplify: true
-  staticcheck:
-    checks: [ "all" ]
-  gocyclo:
-    min-complexity: 58 # This is our baseline at the moment.
-  godot:
-    scope: declarations
-    capital: true
-    period: true
-  govet:
-    enable-all: true
-    disable:
-      - shadow
-      - fieldalignment
-  goimports:
-    local-prefixes: "github.com/openfga/language/pkg/go"
-  importas:
-    no-unaliased: true # Do not allow unaliased imports of aliased packages.
-    no-extra-aliases: false # Do not allow non-required aliases.
-    alias:
-      - pkg: github.com/openfga/api/proto/openfga/v1
-        alias: openfgav1
-
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - path: "(.+)_test.go"
-      linters:
-        - bodyclose
-  exclude:
-    - "should have a package comment" # stylecheck | revive
-    - "exported (.+) should have comment" # revive
-    - "comment on exported (.+) should be of the form" # revive
-    - "(.+) name will be used as (.+) by other packages, and that stutters; consider calling this (.+)" # revive
-    - "Error return value of (.+) is not checked" # errcheck
-    - "unused-parameter" # revive
-    - "exported func (.+) returns unexported type (.+), which can be annoying to use" # revive
+  settings:
+    gocyclo:
+      min-complexity: 58
+    godot:
+      scope: declarations
+      capital: true
+      period: true
+    govet:
+      disable:
+        - shadow
+        - fieldalignment
+      enable-all: true
+    importas:
+      alias:
+        - pkg: github.com/openfga/api/proto/openfga/v1
+          alias: openfgav1
+      no-unaliased: true
+      no-extra-aliases: false
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - bodyclose
+        path: (.+)_test.go
+      - path: (.+)\.go$
+        text: should have a package comment
+      - path: (.+)\.go$
+        text: exported (.+) should have comment
+      - path: (.+)\.go$
+        text: comment on exported (.+) should be of the form
+      - path: (.+)\.go$
+        text: (.+) name will be used as (.+) by other packages, and that stutters; consider calling this (.+)
+      - path: (.+)\.go$
+        text: Error return value of (.+) is not checked
+      - path: (.+)\.go$
+        text: unused-parameter
+      - path: (.+)\.go$
+        text: exported func (.+) returns unexported type (.+), which can be annoying to use
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/openfga/language/pkg/go
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/go/Makefile
+++ b/pkg/go/Makefile
@@ -1,6 +1,7 @@
 BINARY_NAME=openfga-language
 DOCKER_BINARY=docker
 GO_BIN ?= $(shell go env GOPATH)/bin
+GOLANGCI_LINT_VERSION := v2.12.2
 .DEFAULT_GOAL := help
 
 help: ## Show this help
@@ -11,8 +12,8 @@ help: ## Show this help
 # Rules (https://www.gnu.org/software/make/manual/html_node/Rule-Introduction.html#Rule-Introduction)
 #-----------------------------------------------------------------------------------------------------------------------
 $(GO_BIN)/golangci-lint:
-	@echo "==> Installing golangci-lint within "${GO_BIN}""
-	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@echo "==> Installing golangci-lint $(GOLANGCI_LINT_VERSION) within "${GO_BIN}""
+	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GO_BIN)/govulncheck:
 	@echo "==> Installing govulncheck within "${GO_BIN}""
@@ -38,7 +39,7 @@ test: ## Run Go tests
 
 lint: $(GO_BIN)/golangci-lint ## Lint Go source files
 	@echo "==> Linting Go source files"
-	@golangci-lint run -v --fix -c .golangci.yaml ./...
+	@$(GO_BIN)/golangci-lint run -v --fix -c .golangci.yaml ./...
 
 audit: $(GO_BIN)/govulncheck ## Audit Go source files
 	@echo "==> Checking Go source files for vulnerabilities"

--- a/pkg/go/graph/graph_builder_test.go
+++ b/pkg/go/graph/graph_builder_test.go
@@ -1148,9 +1148,10 @@ func TestGetDOTRepresentation_2(t *testing.T) {
 			return err
 		}
 
-		if extension == ".fga" {
+		switch extension {
+		case ".fga":
 			testCases[pathWithoutExtension].model = string(content)
-		} else if extension == ".dot" {
+		case ".dot":
 			testCases[pathWithoutExtension].expectedOutput = string(content)
 		}
 

--- a/pkg/go/graph/weighted_graph.go
+++ b/pkg/go/graph/weighted_graph.go
@@ -39,7 +39,7 @@ func (wg *WeightedAuthorizationModelGraph) GetEdgesFromNodeID(nodeID string) ([]
 
 // Deprecated: Use GetEdgesFromNodeID instead.
 //
-//nolint:revive,stylecheck
+//nolint:revive,staticcheck
 func (wg *WeightedAuthorizationModelGraph) GetEdgesFromNodeId(nodeID string) ([]*WeightedAuthorizationModelEdge, bool) {
 	return wg.GetEdgesFromNodeID(nodeID)
 }

--- a/pkg/go/graph/weighted_graph_builder_test.go
+++ b/pkg/go/graph/weighted_graph_builder_test.go
@@ -667,13 +667,13 @@ func TestValidConditionalGraphModel(t *testing.T) {
 	require.Len(t, conditions, 2)
 	require.Equal(t, NoCond, conditions[0])
 	require.Equal(t, "condX", conditions[1])
-	require.Equal(t, "", edges[0].tuplesetRelation)
+	require.Empty(t, edges[0].tuplesetRelation)
 	edges, _ = graph.GetEdgesFromNode(graph.nodes["role#assignee"])
 	require.Len(t, edges, 1)
 	conditions = edges[0].conditions
 	require.Len(t, conditions, 1)
 	require.Equal(t, NoCond, conditions[0])
-	require.Equal(t, "", edges[0].tuplesetRelation)
+	require.Empty(t, edges[0].tuplesetRelation)
 	edges, _ = graph.GetEdgesFromNode(graph.nodes["permission#member"])
 	require.Len(t, edges, 2)
 	var recursiveEdge *WeightedAuthorizationModelEdge
@@ -689,24 +689,24 @@ func TestValidConditionalGraphModel(t *testing.T) {
 	require.Len(t, conditions, 2)
 	require.Equal(t, NoCond, conditions[0])
 	require.Equal(t, "condX", conditions[1])
-	require.Equal(t, "", recursiveEdge.tuplesetRelation)
+	require.Empty(t, recursiveEdge.tuplesetRelation)
 	conditions = userEdge.conditions
 	require.Len(t, conditions, 1)
 	require.Equal(t, NoCond, conditions[0])
-	require.Equal(t, "", userEdge.tuplesetRelation)
+	require.Empty(t, userEdge.tuplesetRelation)
 	edges, _ = graph.GetEdgesFromNode(graph.nodes["job#owner"])
 	require.Len(t, edges, 1)
 	conditions = edges[0].conditions
 	require.Len(t, conditions, 2)
 	require.Equal(t, NoCond, conditions[0])
 	require.Equal(t, "condX", conditions[1])
-	require.Equal(t, "", edges[0].tuplesetRelation)
+	require.Empty(t, edges[0].tuplesetRelation)
 	edges, _ = graph.GetEdgesFromNode(graph.nodes["job#can_view"])
 	require.Len(t, edges, 1)
 	conditions = edges[0].conditions
 	require.Len(t, conditions, 1)
 	require.Equal(t, NoCond, conditions[0])
-	require.Equal(t, "", edges[0].tuplesetRelation)
+	require.Empty(t, edges[0].tuplesetRelation)
 	edges, _ = graph.GetEdgesFromNode(edges[0].to) // OR node
 	require.Len(t, edges, 2)
 	if edges[0].weights["user"] == Infinite {
@@ -722,7 +722,7 @@ func TestValidConditionalGraphModel(t *testing.T) {
 	require.Equal(t, "job#owner", recursiveEdge.tuplesetRelation)
 	conditions = userEdge.conditions
 	require.Len(t, conditions, 1)
-	require.Equal(t, "", userEdge.tuplesetRelation)
+	require.Empty(t, userEdge.tuplesetRelation)
 	require.Equal(t, NoCond, conditions[0])
 
 	require.Equal(t, 2, graph.nodes["permission#assignee"].weights["user"])

--- a/pkg/go/graph/weighted_graph_edge.go
+++ b/pkg/go/graph/weighted_graph_edge.go
@@ -9,44 +9,44 @@ const (
 	//
 	// e.g. define rel1: [user]
 	// define rel2: [group#member]
-	// define rel3: [user, employee, user:*, user:* with xcond, employee with xcond, group#member, group#member with xcond]
+	// define rel3: [user, employee, user:*, user:* with xcond, employee with xcond, group#member, group#member with xcond].
 	DirectEdge EdgeType = 0
 
 	// RewriteEdge leads from an operator to a relation
 	//
-	// in `define rel1: a OR b`, the edge from `OR --> b` and the edge from rel1 -> OR
+	// In `define rel1: a OR b`, the edge from `OR --> b` and the edge from rel1 -> OR.
 	RewriteEdge EdgeType = 1
 
 	// TTUEdge points to a tuple to userset relation
 	//
-	// e.g. define rel1: admin from parent
+	// E.g. define rel1: admin from parent.
 	TTUEdge EdgeType = 2
 
 	// ComputedEdge points to another relation
 	//
-	// e.g. define rel1: rel2
+	// E.g. define rel1: rel2.
 	ComputedEdge EdgeType = 3
 
-	// DirectLogicalEdge points to the LogicalDirectGrouping of multiple direct edges that are part of an operator node
+	// DirectLogicalEdge points to the LogicalDirectGrouping of multiple direct edges that are part of an operator node.
 	//
-	// define rel1: [user, employee, group#member] or rel2
-	// in this case OR node has two edges, one rewrite edge that goes to rel2 and another one that goes the direct edges grouping
-	// however, when there is a not operator node involved then the LogicalDirectGrouping is not created to avoid unnecessary nested nodes creation
-	// for example in this use case,
-	// define rel1: [user, employee, group#member]
-	// the node rel1 has three direct edges
+	// Define rel1: [user, employee, group#member] or rel2.
+	// In this case the OR node has two edges: one rewrite edge that goes to rel2 and another one that goes to the direct edges grouping.
+	// However, when a not operator node is involved then the LogicalDirectGrouping is not created to avoid unnecessary nested nodes.
+	// For example, in this use case:
+	// Define rel1: [user, employee, group#member].
+	// The node rel1 has three direct edges.
 	DirectLogicalEdge EdgeType = 4
 
-	// TTULogicalEdge points to the LogicalTTUGrouping when a TTU has multiple possible parents and are part of an operator node
-	// For example, if both team and group below had a #viewer relation and viewer from parent is defined as part of a union operation
-	// then a new node is create to group the TTUs
+	// TTULogicalEdge points to the LogicalTTUGrouping when a TTU has multiple possible parents and are part of an operator node.
+	// For example, if both team and group below had a #viewer relation and viewer from parent is defined as part of a union operation,
+	// then a new node is created to group the TTUs.
 	//
-	// define parent: [team, group]
-	// define can_view: viewer from parent or member
-	// however, when there is a not operator node involved then the LogicalTTUGrouping is not created to avoid unnecessary nested nodes creation
-	// for example in this use case no LogicalTTUGrouping is created, the two ttu edges are referenced directly from the can_view relation node
-	// define can_view: viewer from parent
-	// define parent: [team, group]
+	// Define parent: [team, group].
+	// Define can_view: viewer from parent or member.
+	// However, when a not operator node is involved then the LogicalTTUGrouping is not created to avoid unnecessary nested nodes.
+	// For example, in this use case no LogicalTTUGrouping is created and the two TTU edges are referenced directly from the can_view relation node.
+	// Define can_view: viewer from parent.
+	// Define parent: [team, group].
 	TTULogicalEdge EdgeType = 5
 
 	// When an edge does not have cond in the model, it will have a condition with value none.

--- a/pkg/go/graph/weighted_graph_test.go
+++ b/pkg/go/graph/weighted_graph_test.go
@@ -1206,8 +1206,8 @@ func TestValidMixedRecursionWithTupleCycles(t *testing.T) {
 	require.Equal(t, "state-member", graph.nodes["state-member"].recursiveRelation)
 	require.Equal(t, "state-member", graph.nodes["state-member-or"].recursiveRelation)
 	require.Equal(t, "state-member", graph.nodes["state-member-or-or"].recursiveRelation)
-	require.Equal(t, "", graph.nodes["state-parent"].recursiveRelation)
-	require.Equal(t, "", graph.nodes["state-parent_member"].recursiveRelation)
+	require.Empty(t, graph.nodes["state-parent"].recursiveRelation)
+	require.Empty(t, graph.nodes["state-parent_member"].recursiveRelation)
 
 	require.True(t, graph.nodes["state-member"].tupleCycle)
 	require.True(t, graph.nodes["state-member-or"].tupleCycle)

--- a/pkg/go/transformer/dsltojson.go
+++ b/pkg/go/transformer/dsltojson.go
@@ -14,10 +14,10 @@ import (
 type RelationDefinitionOperator string
 
 const (
-	RELATION_DEFINITION_OPERATOR_NONE    RelationDefinitionOperator = ""        //nolint:stylecheck,revive
-	RELATION_DEFINITION_OPERATOR_OR      RelationDefinitionOperator = "or"      //nolint:stylecheck,revive
-	RELATION_DEFINITION_OPERATOR_AND     RelationDefinitionOperator = "and"     //nolint:stylecheck,revive
-	RELATION_DEFINITION_OPERATOR_BUT_NOT RelationDefinitionOperator = "but not" //nolint:stylecheck,revive
+	RELATION_DEFINITION_OPERATOR_NONE    RelationDefinitionOperator = ""        //nolint:staticcheck,revive
+	RELATION_DEFINITION_OPERATOR_OR      RelationDefinitionOperator = "or"      //nolint:staticcheck,revive
+	RELATION_DEFINITION_OPERATOR_AND     RelationDefinitionOperator = "and"     //nolint:staticcheck,revive
+	RELATION_DEFINITION_OPERATOR_BUT_NOT RelationDefinitionOperator = "but not" //nolint:staticcheck,revive
 )
 
 // OpenFGA DSL Listener

--- a/pkg/go/transformer/jsontodsl_test.go
+++ b/pkg/go/transformer/jsontodsl_test.go
@@ -49,7 +49,7 @@ func TestJSONToDSLTransformerForSyntaxErrorCases(t *testing.T) {
 			if testCase.ErrorMessage == "" {
 				require.NoError(t, err)
 			} else {
-				require.EqualErrorf(t, err, testCase.ErrorMessage, "")
+				require.EqualError(t, err, testCase.ErrorMessage)
 			}
 		})
 	}

--- a/pkg/go/transformer/module-to-model_test.go
+++ b/pkg/go/transformer/module-to-model_test.go
@@ -59,7 +59,7 @@ func TestTransformModuleToJSON(t *testing.T) {
 				if errors.As(err, &verr) {
 					errors := verr.Errors
 
-					require.Equal(t, len(errors), len(testCase.ExpectedErrors), "did not get the expected amount of errors")
+					require.Len(t, errors, len(testCase.ExpectedErrors), "did not get the expected amount of errors")
 
 					for i := 0; i < len(testCase.ExpectedErrors); i++ {
 						errorDetails := testCase.ExpectedErrors[i]


### PR DESCRIPTION
## Summary

- run the same pinned golangci-lint GitHub Action and v2.12.2 release used by OpenFGA CLI
- migrate the Go lint configuration to golangci-lint v2
- replace the unpinned Makefile linter installation with a pinned v2.12.2 install, and resolve the v2 lint findings

Fixes [openfga/cli#630](https://github.com/openfga/cli/issues/630)

## Testing

- `make GO_BIN=/tmp/golangci-lint lint`
- `go test ./... -count=1 -race`

## Status

Deferred to avoid conflicts with the planned language changes from `develop`; the branch remains available in the fork for a later rebase.