### PR TITLE
chore(ci): pin the Go version used by the lint job

### DIFF
--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -22,6 +22,7 @@ jobs:
           # in pkg/go/Makefile.
           go-version: "1.26"
           cache-dependency-path: "./pkg/go/go.sum"
+          check-latest: true
 
       - name: Audit dependencies
         run: make audit-go

--- a/.github/workflows/pkg-go-build.yaml
+++ b/.github/workflows/pkg-go-build.yaml
@@ -16,9 +16,12 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=1.25.0"
+          # golangci-lint v1 cannot read export data emitted by Go 1.27 or later,
+          # so the lint job tracks the newest Go the linter supports rather than
+          # the newest Go available. Raise this together with the linter version
+          # in pkg/go/Makefile.
+          go-version: "1.26"
           cache-dependency-path: "./pkg/go/go.sum"
-          check-latest: true
 
       - name: Audit dependencies
         run: make audit-go

--- a/pkg/go/Makefile
+++ b/pkg/go/Makefile
@@ -1,6 +1,7 @@
 BINARY_NAME=openfga-language
 DOCKER_BINARY=docker
 GO_BIN ?= $(shell go env GOPATH)/bin
+GOLANGCI_LINT_VERSION ?= v1.64.8
 .DEFAULT_GOAL := help
 
 help: ## Show this help
@@ -12,7 +13,7 @@ help: ## Show this help
 #-----------------------------------------------------------------------------------------------------------------------
 $(GO_BIN)/golangci-lint:
 	@echo "==> Installing golangci-lint within "${GO_BIN}""
-	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GO_BIN)/govulncheck:
 	@echo "==> Installing govulncheck within "${GO_BIN}""


### PR DESCRIPTION
The lint job asked for >=1.25.0 with check-latest, so it moved to Go 1.27 as soon as that showed up in the manifest. golangci-lint v1.64.8 cannot read Go 1.27 export data and reports every antlr symbol in pkg/go/gen as undefined. The build matrix pins 1.25 and 1.26, which is why only lint went red.

So pin the toolchain to 1.26 and pin the linter version next to it so the two are raised together.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the Go linting environment on Go 1.26 for consistent checks.
  - Pinned the Go linter to a stable, configurable version to improve build reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->